### PR TITLE
Forbid the access to data through a $lckGroupId the user is not member of

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -108,7 +108,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # Others
-/lib/
+lib/
 data/
 
 .env

--- a/api/src/services/group/group.service.ts
+++ b/api/src/services/group/group.service.ts
@@ -39,7 +39,7 @@ export default function (app: Application): void {
       '$joinRelated',
       '$joinEager',
     ],
-    allowedEager: '[users, usergroups, aclset.[workspace.[chapters.[pages], databases], chapter]]',
+    allowedEager: '[users, usergroups, aclset.[workspace.[chapters.[pages], databases], chapter.[pages]]]',
     allowedInsert: 'users',
     insertGraphOptions: {
       relate: true,

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 node_modules
-/dist
+dist
 
 # Config
 /public/config.js

--- a/front/src/views/routes/common/group/CommonGroupListing.vue
+++ b/front/src/views/routes/common/group/CommonGroupListing.vue
@@ -228,7 +228,7 @@ export default {
       try {
         const groupParams: Params = {
           query: {
-            $limit: 100,
+            $limit: -1,
           },
         }
         /**
@@ -238,8 +238,8 @@ export default {
           groupParams.query!.$joinRelation = '[aclset.[workspace]]'
           groupParams.query!['aclset:workspace.id'] = this.workspaceId
         }
-        const responseGroups = await lckServices.group.find(groupParams) as Paginated<LckGroup>
-        this.groups = responseGroups.data
+        const responseGroups = await lckServices.group.find(groupParams) as LckGroup[]
+        this.groups = responseGroups
       } catch (error: any) {
         this.displayToastOnError(error)
       }


### PR DESCRIPTION
This address the use case of a user that would retrieve data through a group he's not member of.

Actually, a security breach allows users that would know other group ids to access their data, and update it.

I add some tests to prevent these use-cases.