### PR TITLE
:bug: Fix how we retrieve workspaceId from query params in attachment abilities

### DIFF
--- a/front/src/services/lck-api/helpers.ts
+++ b/front/src/services/lck-api/helpers.ts
@@ -351,7 +351,7 @@ export async function uploadMultipleFiles (fileList: FileList, workspaceId: stri
           ...fileType,
         }, {
           query: {
-            workspaceId,
+            workspace_id: workspaceId,
             fileName: file.name,
             ...fileType,
           },


### PR DESCRIPTION
closes #183 