### PR TITLE
[ci/cd] Use of matrix platform to parallelize docker images build

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -169,9 +169,9 @@ jobs:
   docker-api-build:
     runs-on: ubuntu-latest
     needs: general-build
-    strategy:
-      matrix:
-        platform: [linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7]
+    # strategy:
+    #   matrix:
+    #     platform: [linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -230,16 +230,17 @@ jobs:
           tags: ${{ steps.metapi.outputs.tags }}
           target: locokit-api
           labels: ${{ steps.metapi.outputs.labels }}
-          platforms: ${{ matrix.platform }}
+          # platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   docker-app-build:
     runs-on: ubuntu-latest
     needs: general-build
-    strategy:
-      matrix:
-        platform: [linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7]
+    # strategy:
+    #   matrix:
+    #     platform: [linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -290,6 +291,7 @@ jobs:
           tags: ${{ steps.metapp.outputs.tags }}
           target: locokit-app
           labels: ${{ steps.metapp.outputs.labels }}
-          platforms: ${{ matrix.platform }}
+          # platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -11,6 +11,10 @@ on:
 
 jobs:
 
+  #
+  # Quality section
+  #
+
   ## Design system
   # design-system-quality:
   #   runs-on: ubuntu-latest
@@ -101,29 +105,6 @@ jobs:
           name: lck-api-quality-artifact.tar.gz
           path: lck-api-quality-artifact.tar.gz
 
-  api-build:
-    runs-on: ubuntu-latest
-    container: node:18
-    steps:
-      - uses: actions/checkout@v3
-      - name: NPM Version
-        run: npm -v
-      - name: Install Turbo
-        run: npm i -g turbo
-      - name: Install dependencies
-        run: npm ci --ignore-scripts --include=dev
-      - name: Build API lib
-        run: turbo run build --scope=locokit-api
-      - name: Tar build
-        run: tar -cvzf lck-api-build-artifact.tar.gz api/dist/server
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: lck-api-build-artifact.tar.gz
-          path: lck-api-build-artifact.tar.gz
-
-  # api-docker:
-
   ## Documentation part
   docs-build:
     runs-on: ubuntu-latest
@@ -145,6 +126,9 @@ jobs:
           path: |
             docs/.vitepress/dist/lck-docs-build-artifact.tar.gz
 
+  #
+  # Build section
+  #
   general-build:
     runs-on: ubuntu-latest
     container: node:18
@@ -173,7 +157,7 @@ jobs:
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: lck-build-artifact
+          name: lck-build-artifact-${{ github.sha }}
           path: |
             lck-api-build-artifact.tar.gz
             lck-app-build-artifact.tar.gz
@@ -181,3 +165,131 @@ jobs:
             locokit-designsystem-build-artifact.tar.gz
             locokit-engine-build-artifact.tar.gz
             nuxt-locokit-build-artifact.tar.gz
+
+  docker-api-build:
+    runs-on: ubuntu-latest
+    needs: general-build
+    strategy:
+      matrix:
+        platform: [linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: lck-build-artifact-${{ github.sha }}
+      - name: List files
+        run: ls -al
+      - name: Extract build api
+        run: tar -xzf lck-api-build-artifact.tar.gz
+      - name: Extract build @locokit/definitions
+        run: tar -xzf locokit-definitions-build-artifact.tar.gz
+      - name: Extract build @locokit/engine
+        run: tar -xzf locokit-engine-build-artifact.tar.gz
+      - name: List files
+        run: ls -al api
+      - name: List files
+        run: ls -al packages/definitions
+      - name: List files
+        run: ls -al packages/engine
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Print GITHUB REF
+        run: echo $GITHUB_REF
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: metapi
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            locokit/api
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Build and push locokit/api
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./DockerfileGHA
+          push: true
+          tags: ${{ steps.metapi.outputs.tags }}
+          target: locokit-api
+          labels: ${{ steps.metapi.outputs.labels }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-app-build:
+    runs-on: ubuntu-latest
+    needs: general-build
+    strategy:
+      matrix:
+        platform: [linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: lck-build-artifact-${{ github.sha }}
+      - name: List files
+        run: ls -al
+      - name: Extract build app
+        run: tar -xzf lck-app-build-artifact.tar.gz
+      - name: List files
+        run: ls -al app
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Print GITHUB REF
+        run: echo $GITHUB_REF
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: metapp
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            locokit/app
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Build and push locokit/app
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./DockerfileGHA
+          push: true
+          tags: ${{ steps.metapp.outputs.tags }}
+          target: locokit-app
+          labels: ${{ steps.metapp.outputs.labels }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -144,3 +144,40 @@ jobs:
           name: lck-docs-build-artifact.tar.gz
           path: |
             docs/.vitepress/dist/lck-docs-build-artifact.tar.gz
+
+  general-build:
+    runs-on: ubuntu-latest
+    container: node:18
+    steps:
+      - uses: actions/checkout@v3
+      - name: NPM Version
+        run: npm -v
+      - name: Install Turbo
+        run: npm i -g turbo
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --include=dev
+      - name: Build all project
+        run: turbo run build
+      - name: Tar build api
+        run: tar -cvzf lck-api-build-artifact.tar.gz api/dist/server
+      - name: Tar build app
+        run: tar -cvzf lck-app-build-artifact.tar.gz app/.output
+      - name: Tar build @locokit/definitions
+        run: tar -cvzf locokit-definitions-build-artifact.tar.gz packages/definitions/dist
+      - name: Tar build @locokit/designsystem
+        run: tar -cvzf locokit-designsystem-build-artifact.tar.gz packages/designsystem/dist
+      - name: Tar build @locokit/engine
+        run: tar -cvzf locokit-engine-build-artifact.tar.gz packages/engine/dist
+      - name: Tar build nuxt-locokit
+        run: tar -cvzf nuxt-locokit-build-artifact.tar.gz packages/nuxt-locokit/dist
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: lck-build-artifact
+          path: |
+            lck-api-build-artifact.tar.gz
+            lck-app-build-artifact.tar.gz
+            locokit-definitions-build-artifact.tar.gz
+            locokit-designsystem-build-artifact.tar.gz
+            locokit-engine-build-artifact.tar.gz
+            nuxt-locokit-build-artifact.tar.gz

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Build all project
         run: turbo run build
       - name: Tar build api
-        run: tar -cvzf lck-api-build-artifact.tar.gz api/dist/server
+        run: tar -cvzf lck-api-build-artifact.tar.gz api/dist
       - name: Tar build app
         run: tar -cvzf lck-app-build-artifact.tar.gz app/.output
       - name: Tar build @locokit/definitions

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   locokit-api-all:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,8 +60,7 @@ jobs:
           tags: ${{ steps.metapi.outputs.tags }}
           target: locokit-api
           labels: ${{ steps.metapi.outputs.labels }}
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7
-          # platforms: linux/arm/v7
+          platforms: ${{ matrix.platform }}
       - name: Docker meta
         id: metapp
         uses: docker/metadata-action@v3
@@ -83,5 +85,4 @@ jobs:
           tags: ${{ steps.metapp.outputs.tags }}
           target: locokit-app
           labels: ${{ steps.metapp.outputs.labels }}
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7
-          # platforms: linux/arm/v7
+          platforms: ${{ matrix.platform }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Docker meta
         id: metapi
         uses: docker/metadata-action@v3
@@ -40,6 +41,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -61,6 +63,9 @@ jobs:
           target: locokit-api
           labels: ${{ steps.metapi.outputs.labels }}
           platforms: ${{ matrix.platform }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Docker meta
         id: metapp
         uses: docker/metadata-action@v3
@@ -86,3 +91,5 @@ jobs:
           target: locokit-app
           labels: ${{ steps.metapp.outputs.labels }}
           platforms: ${{ matrix.platform }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,8 +13,6 @@ on:
   push:
     branches:
       - next
-  # TODO: when the 239 branch will be merged in next, remove this line
-  pull_request:
 
 jobs:
   locokit-api-all:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
 #
+# This file is here to build 2 docker images : locokit-api & locokit-app
+#
+# This docker file works for amd64 and arm64 platform only
+#
+# It use turbo (https://turbo.build/) and this bundler doesn't work only on arm32 platform
+# see https://github.com/vercel/turbo/issues/4935
+#
+
+#
 # Base image
 #
 # To be used by all others images

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ FROM base AS locokit-api
 WORKDIR /code
 COPY --from=builder /code/locokit-api/json .
 RUN npm ci --ignore-scripts
-COPY --from=builder /code/locokit-api/full/api/dist/server .
-COPY --from=builder /code/locokit-api/full/api/dist/server /code/api/dist/server
+COPY --from=builder /code/locokit-api/full/api/dist .
+COPY --from=builder /code/locokit-api/full/api/dist /code/api/dist
 COPY --from=builder /code/locokit-api/full/packages/definitions/dist /code/packages/definitions/dist
 COPY --from=builder /code/locokit-api/full/packages/engine/dist /code/packages/engine/dist
 

--- a/DockerfileARM32bits
+++ b/DockerfileARM32bits
@@ -1,4 +1,14 @@
 #
+# This file is here to build 2 docker images : locokit-api & locokit-app
+#
+# This docker file can work for both amd64 and arm32/64 platforms (v6, v7, v8)
+# as it doesn't use turbo (https://turbo.build/)
+#
+# Indeed, turbo doesn't work for arm32 platforms
+# see https://github.com/vercel/turbo/issues/4935
+#
+
+#
 # Base image
 #
 # To be used by all others images

--- a/DockerfileARM32bits
+++ b/DockerfileARM32bits
@@ -58,7 +58,7 @@ COPY --from=builder /code/packages/engine/package.json /code/packages/engine/
 COPY --from=builder /code/package.json .
 COPY --from=builder /code/package-lock.json .
 RUN npm ci --ignore-scripts
-COPY --from=builder /code/api/dist/server .
+COPY --from=builder /code/api/dist .
 COPY --from=builder /code/packages/definitions/dist /code/packages/definitions/dist
 COPY --from=builder /code/packages/engine/dist /code/packages/engine/dist
 

--- a/DockerfileGHA
+++ b/DockerfileGHA
@@ -35,7 +35,7 @@ COPY packages/engine/package.json /code/packages/engine/
 COPY package.json .
 COPY package-lock.json .
 RUN npm ci --ignore-scripts
-COPY api/dist/server .
+COPY api/dist .
 COPY packages/definitions/dist /code/packages/definitions/dist
 COPY packages/engine/dist /code/packages/engine/dist
 

--- a/DockerfileGHA
+++ b/DockerfileGHA
@@ -1,0 +1,55 @@
+#
+# This file is here to build 2 docker images : locokit-api & locokit-app
+#
+# This docker file is only for GitHub Action
+#
+# Please don't use in local development
+#
+# It needs other jobs in the CI/CD to be already done to retrieve artifacts
+#
+
+#
+# Base image
+#
+# To be used by all others images
+#
+FROM node:18-alpine AS base
+RUN apk add --no-cache libc6-compat nano
+RUN apk update
+RUN npm i --ignore-scripts -g pm2
+RUN addgroup -S locokit \
+    && adduser -S locokit -G locokit
+
+# Environment variables default values
+ENV NODE_ENV=production
+
+#
+# LocoKit API image
+# Koa NodeJS web server for the Feathers API
+#
+FROM base AS locokit-api
+WORKDIR /code
+COPY api/package.json /code/api/
+COPY packages/definitions/package.json /code/packages/definitions/
+COPY packages/engine/package.json /code/packages/engine/
+COPY package.json .
+COPY package-lock.json .
+RUN npm ci --ignore-scripts
+COPY api/dist/server .
+COPY packages/definitions/dist /code/packages/definitions/dist
+COPY packages/engine/dist /code/packages/engine/dist
+
+USER locokit
+CMD pm2 start index.js
+
+#
+# LocoKit APP image
+# Nitro web server for the Nuxt application
+#
+FROM base AS locokit-app
+WORKDIR /code
+COPY app/.output .
+
+USER locokit
+CMD pm2 start server/index.mjs
+

--- a/api/package.json
+++ b/api/package.json
@@ -27,7 +27,7 @@
   "browser": "dist/client",
   "scripts": {
     "dev": "vite",
-    "build": "rm -rf dist/server && vite build --outDir dist/server --ssr src/index.ts",
+    "build": "rm -rf dist && vite build --ssr src/index.ts",
     "debug": "DEBUG=* ts-node-dev --no-notify --files src/",
     "tsc:dev": "ts-node-dev --no-notify --files src/index.ts",
     "tsc:build": "rm -rf lib/ && tsc -p tsconfig.build.json",

--- a/api/seeds/init.ts
+++ b/api/seeds/init.ts
@@ -74,6 +74,7 @@ export async function seed(knex: Knex): Promise<any> {
       slug: 'ds_nutrieduc13',
       client: 'sqlite3',
       connection: './nutrieduc13.db',
+      type: 'remote',
     },
   ]
   await knex('datasource')

--- a/api/vite.config.ts
+++ b/api/vite.config.ts
@@ -91,6 +91,7 @@ export default defineConfig(() => {
   return {
     publicDir: false,
     build: {
+      outDir: 'dist',
       sourcemap: true,
       lib: {
         entry: {


### PR DESCRIPTION
Related to #248 

Actually, docker images builds are too long (~ one hour).
This PR try to reduce the time of build.

By removing the docker workflow, and mixing the docker builds in the api workflow, it allows us the reuse of build artifacts.

We build all packages in `general-build` and reuse it in the `docker-{api/app}-build` jobs.

I add also cache directives with gha. Don't know if it's really useful. Will check this in the future workflows to see if any decrease in build time is observable.