### PR TITLE
Issue #127 - Limit concurrent GitHub workflow runs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,14 @@ on:
     branches:
       - next
 
+concurrency:
+  group: >-
+    ${{ github.event_name == 'push'
+      && format('{0}-{1}', github.workflow, github.ref)
+      || format('{0}-{1}', github.workflow, github.run_id)
+    }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 jobs:
   locokit-api-all:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: >-
+    ${{ github.event_name == 'pull_request'
+      && format('{0}-{1}', github.workflow, github.ref)
+      || format('{0}-{1}', github.workflow, github.run_id)
+    }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   #


### PR DESCRIPTION
This addition to the `main` workflow should prevent concurrent workflow runs for a same pull request, but keep all queued workflow runs for pushes on the `next` branch. If a workflow is already running, it is canceled if it concerns a pull request, not for pushes on the `next` branch.

@mdartic Is that OK for you or would you prefer a stricter configuration? I mean limit even more concurrent workflow runs.