### PR TITLE
feat: security for core services (datasource / group)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: lck-build-artifact-${{ github.sha }}
       - name: List files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
       "column": 100
     }
   ],
-  "workbench.colorTheme": "Default Dark Modern",
+  "workbench.colorTheme": "Default Light Modern",
   "workbench.colorCustomizations": {
     "activityBar.background": "#1f5665",
     "activityBar.foreground": "#f9b232",

--- a/api/migrations/20250124124800_group_cascade_usergroup.ts
+++ b/api/migrations/20250124124800_group_cascade_usergroup.ts
@@ -1,0 +1,33 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.withSchema('core').alterTable('lck_userGroup', (table) => {
+    table
+      .dropForeign('groupId', 'FK_userGroup_group')
+      .foreign('groupId', 'FK_userGroup_group')
+      .references('id')
+      .inTable('core.lck_group')
+      .onDelete('CASCADE')
+    table
+      .dropForeign('userId', 'FK_userGroup_user')
+      .foreign('userId', 'FK_userGroup_user')
+      .references('id')
+      .inTable('core.lck_user')
+      .onDelete('CASCADE')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.withSchema('core').alterTable('lck_userGroup', (table) => {
+    table
+      .dropForeign('groupId', 'FK_userGroup_group')
+      .foreign('groupId', 'FK_userGroup_group')
+      .references('id')
+      .inTable('core.lck_group')
+    table
+      .dropForeign('userId', 'FK_userGroup_user')
+      .foreign('userId', 'FK_userGroup_user')
+      .references('id')
+      .inTable('core.lck_user')
+  })
+}

--- a/api/package.json
+++ b/api/package.json
@@ -50,7 +50,7 @@
     "client:bundle:watch": "vite build -c vite.client.config.ts --watch"
   },
   "dependencies": {
-    "@casl/ability": "^5.4.4",
+    "@casl/ability": "^6.7.3",
     "@directus/schema": "^12.1.0",
     "@feathersjs/adapter-commons": "5.0.10",
     "@feathersjs/authentication": "5.0.10",
@@ -79,6 +79,7 @@
     "dotenv-flow": "^3.3.0",
     "ejs": "^3.1.10",
     "feathers-authentication-management": "^5.0.1",
+    "feathers-casl": "^2.2.0",
     "feathers-hooks-common": "^7.0.3",
     "feathers-swagger": "^3.0.0",
     "knex": "^3.1.0",

--- a/api/seeds/test.ts
+++ b/api/seeds/test.ts
@@ -17,6 +17,8 @@ export async function seed(knex: Knex): Promise<any> {
     )
 
     console.log('All workspaces dedicated schemas removed')
+    await knex('lck_group').withSchema('core').transacting(trx).delete()
+    await knex('lck_policy').withSchema('core').transacting(trx).delete()
     await knex('lck_workspace').withSchema('core').transacting(trx).delete()
     console.log('Workspaces removed')
 

--- a/api/src/abilities/authorize.ts
+++ b/api/src/abilities/authorize.ts
@@ -1,1 +1,0 @@
-export const authorize = async () => {}

--- a/api/src/abilities/definitions.ts
+++ b/api/src/abilities/definitions.ts
@@ -1,20 +1,6 @@
 /**
  * Load of all ressources we want to manage with CASL
  */
-/**
- * user
- * group
- * (organization ?)
- * workspace
- * datasource
- *
- * media
- *
- * application
- *
- * automation
- *
- */
 // import { Workspace } from '../models/workspace.model'
 // import { LckAttachment } from '../models/attachment.model'
 // import { Block } from '../models/block.model'
@@ -33,14 +19,14 @@
 // import { TableColumnRelation } from '../models/tablecolumnrelation.model'
 
 // import { UsersResult } from '../services/users/users.schema'
-import { WorkspaceService } from '@/services/core/workspace/workspace.class'
+// import { WorkspaceService } from '@/services/core/workspace/workspace.class'
 
 import {
-  AbilityClass,
+  //   AbilityClass,
   createAliasResolver,
-  InferSubjects,
-  PureAbility,
-  Ability,
+  //   InferSubjects,
+  //   PureAbility,
+  //   Ability,
 } from '@casl/ability'
 
 /**
@@ -57,14 +43,14 @@ export type Actions =
   | 'manage'
   | 'read'
   | 'delete'
-export type Subjects = InferSubjects<
-  'all' | 'user' | 'group' | 'workspace' | 'datasource' | typeof WorkspaceService,
-  true
->
+// export type Subjects = InferSubjects<
+//   'all' | 'user' | 'group' | 'workspace' | 'datasource' | typeof WorkspaceService,
+//   true
+// >
 
-export type AppAbility = Ability<[Actions, Subjects]>
+// export type AppAbility = Ability<[Actions, Subjects]>
 
-export const AppAbility = PureAbility as AbilityClass<AppAbility>
+// export const AppAbility = PureAbility as AbilityClass<AppAbility>
 
 export const resolveAction = createAliasResolver({
   update: 'patch', // define the same rules for update & patch

--- a/api/src/configure.test.ts
+++ b/api/src/configure.test.ts
@@ -195,6 +195,7 @@ export function builderTestEnvironment(prefix: string) {
         email: `${prefix}abilities-user3@locokit.io`,
         isVerified: true,
         password: passwordHashed,
+        profile: USER_PROFILE.MEMBER,
       },
       {},
     )
@@ -205,6 +206,7 @@ export function builderTestEnvironment(prefix: string) {
         email: `${prefix}abilities-user4@locokit.io`,
         isVerified: true,
         password: passwordHashed,
+        profile: USER_PROFILE.CREATOR,
       },
       {},
     )
@@ -256,20 +258,6 @@ export function builderTestEnvironment(prefix: string) {
       createdBy: user2.id,
       public: false,
     })
-    // const workspaceDatabases = (await app.service('database').find({
-    //   query: {
-    //     workspace_id: workspace1.id,
-    //     $limit: 1,
-    //   },
-    // })) as Paginated<Database>
-    // database1 = workspaceDatabases.data[0]
-    // const workspace2Databases = (await app.service('database').find({
-    //   query: {
-    //     workspace_id: workspace2.id,
-    //     $limit: 1,
-    //   },
-    // })) as Paginated<Database>
-    // database2 = workspace2Databases.data[0]
 
     /**
      * 3 Then policies
@@ -307,37 +295,36 @@ export function builderTestEnvironment(prefix: string) {
 
     group1 = await app.service(SERVICES.CORE_GROUP).create({
       name: `[${prefix} policy] Group 1`,
-      workspaceId: workspace2.id,
+      workspaceId: publicWorkspace.id,
       policyId: policy1.id,
-      // users: [user1, user4],
     })
     group2 = await app.service(SERVICES.CORE_GROUP).create({
       name: `[${prefix} policy] Group 2`,
-      workspaceId: workspace2.id,
+      workspaceId: publicWorkspace.id,
       policyId: policy2.id,
-      // users: [user2, user3, user5],
     })
     group3 = await app.service(SERVICES.CORE_GROUP).create({
       name: `[${prefix} policy] Group 3`,
       workspaceId: workspace2.id,
       policyId: policy3.id,
-      // users: [user2],
     })
     group4 = await app.service(SERVICES.CORE_GROUP).create({
       name: `[${prefix} policy] Group 4`,
       workspaceId: workspace2.id,
       policyId: policy4.id,
-      // users: [user1, user5],
     })
     group5 = await app.service(SERVICES.CORE_GROUP).create({
       name: `[${prefix} policy] Group 5`,
-      workspaceId: workspace2.id,
+      workspaceId: publicWorkspace.id,
       policyId: policy5.id,
-      // users: [user5],
     })
 
     await app.service(SERVICES.CORE_USERGROUP).create({
       userId: user1.id,
+      groupId: group1.id,
+    })
+    await app.service(SERVICES.CORE_USERGROUP).create({
+      userId: user2.id,
       groupId: group1.id,
     })
     await app.service(SERVICES.CORE_USERGROUP).create({

--- a/api/src/configure.test.ts
+++ b/api/src/configure.test.ts
@@ -336,6 +336,23 @@ export function builderTestEnvironment(prefix: string) {
       // users: [user5],
     })
 
+    await app.service(SERVICES.CORE_USERGROUP).create({
+      userId: user1.id,
+      groupId: group1.id,
+    })
+    await app.service(SERVICES.CORE_USERGROUP).create({
+      userId: user1.id,
+      groupId: group2.id,
+    })
+    await app.service(SERVICES.CORE_USERGROUP).create({
+      userId: user2.id,
+      groupId: group3.id,
+    })
+    await app.service(SERVICES.CORE_USERGROUP).create({
+      userId: user4.id,
+      groupId: group4.id,
+    })
+
     user1Authentication = await app.service(SERVICES.AUTH_AUTHENTICATION).create(
       {
         strategy: 'local',

--- a/api/src/configure.test.ts
+++ b/api/src/configure.test.ts
@@ -24,7 +24,7 @@ const app = createApp()
 
 export interface SetupData {
   publicWorkspaceId: string
-  workspace2Id: string
+  privateWorkspaceId: string
   // database1Id: string
   // database2Id: string
   // columnTable1GroupId: string
@@ -35,17 +35,17 @@ export interface SetupData {
   // columnTable2LkdUpUserId: string
   // columnTable1W2Ref: string
   // columnTable1W2Name: string
-  user1: UserResult
+  userCreator1: UserResult
   user2: UserResult
   user3: UserResult
-  user4: UserResult
+  userCreator4: UserResult
   user5: UserResult
   userAdmin: UserResult
   userBlocked: UserResult
-  user1Authentication: AuthenticationResult
+  userCreator1Authentication: AuthenticationResult
   user2Authentication: AuthenticationResult
   user3Authentication: AuthenticationResult
-  user4Authentication: AuthenticationResult
+  userCreator4Authentication: AuthenticationResult
   user5Authentication: AuthenticationResult
   userAdminAuthentication: AuthenticationResult
   group1: GroupResult
@@ -85,7 +85,7 @@ export function builderTestEnvironment(prefix: string) {
    */
   let _data: SetupData
   let publicWorkspace: WorkspaceResult
-  let workspace2: WorkspaceResult
+  let privateWorkspace: WorkspaceResult
   // let database1: Database
   // let database2: Database
   let policy1: PolicyResult
@@ -98,17 +98,17 @@ export function builderTestEnvironment(prefix: string) {
   let group3: GroupResult
   let group4: GroupResult
   let group5: GroupResult
-  let user1: UserResult
+  let userCreator1: UserResult
   let user2: UserResult
   let user3: UserResult
-  let user4: UserResult
+  let userCreator4: UserResult
   let user5: UserResult
   let userAdmin: UserResult
   let userBlocked: UserResult
-  let user1Authentication: AuthenticationResult
+  let userCreator1Authentication: AuthenticationResult
   let user2Authentication: AuthenticationResult
   let user3Authentication: AuthenticationResult
-  let user4Authentication: AuthenticationResult
+  let userCreator4Authentication: AuthenticationResult
   let user5Authentication: AuthenticationResult
   let userAdminAuthentication: AuthenticationResult
 
@@ -166,7 +166,7 @@ export function builderTestEnvironment(prefix: string) {
     const passwordHashed = await localStrategy.hashPassword(userPassword, {})
 
     // @ts-expect-error don't respectful of the UserData schema (we provide a password)
-    user1 = await app.service(SERVICES.CORE_USER)._create(
+    userCreator1 = await app.service(SERVICES.CORE_USER)._create(
       {
         username: `${prefix}-user1`,
         email: `${prefix}abilities-user1@locokit.io`,
@@ -200,7 +200,7 @@ export function builderTestEnvironment(prefix: string) {
       {},
     )
     // @ts-expect-error don't respectful of the UserData schema (we provide a password)
-    user4 = await app.service(SERVICES.CORE_USER)._create(
+    userCreator4 = await app.service(SERVICES.CORE_USER)._create(
       {
         username: `${prefix}-user4`,
         email: `${prefix}abilities-user4@locokit.io`,
@@ -249,11 +249,11 @@ export function builderTestEnvironment(prefix: string) {
     publicWorkspace = await app.service(SERVICES.CORE_WORKSPACE).create({
       name: `[${prefix}] Public workspace 1`,
       documentation: 'Public workspace for user1',
-      createdBy: user1.id,
+      createdBy: userCreator1.id,
       public: true,
     })
 
-    workspace2 = await app.service(SERVICES.CORE_WORKSPACE).create({
+    privateWorkspace = await app.service(SERVICES.CORE_WORKSPACE).create({
       name: `[${prefix}] Workspace 2`,
       createdBy: user2.id,
       public: false,
@@ -276,13 +276,13 @@ export function builderTestEnvironment(prefix: string) {
     })
     policy3 = await app.service(SERVICES.CORE_POLICY).create({
       name: `[${prefix} abilities] Acl Set 3 workspace 2`,
-      workspaceId: workspace2.id,
+      workspaceId: privateWorkspace.id,
       manager: true,
       public: false,
     })
     policy4 = await app.service(SERVICES.CORE_POLICY).create({
       name: `[${prefix} abilities] Acl Set 4 workspace 2`,
-      workspaceId: workspace2.id,
+      workspaceId: privateWorkspace.id,
       manager: false,
       public: false,
     })
@@ -305,12 +305,12 @@ export function builderTestEnvironment(prefix: string) {
     })
     group3 = await app.service(SERVICES.CORE_GROUP).create({
       name: `[${prefix} policy] Group 3`,
-      workspaceId: workspace2.id,
+      workspaceId: privateWorkspace.id,
       policyId: policy3.id,
     })
     group4 = await app.service(SERVICES.CORE_GROUP).create({
       name: `[${prefix} policy] Group 4`,
-      workspaceId: workspace2.id,
+      workspaceId: privateWorkspace.id,
       policyId: policy4.id,
     })
     group5 = await app.service(SERVICES.CORE_GROUP).create({
@@ -320,7 +320,7 @@ export function builderTestEnvironment(prefix: string) {
     })
 
     await app.service(SERVICES.CORE_USERGROUP).create({
-      userId: user1.id,
+      userId: userCreator1.id,
       groupId: group1.id,
     })
     await app.service(SERVICES.CORE_USERGROUP).create({
@@ -328,7 +328,7 @@ export function builderTestEnvironment(prefix: string) {
       groupId: group1.id,
     })
     await app.service(SERVICES.CORE_USERGROUP).create({
-      userId: user1.id,
+      userId: userCreator1.id,
       groupId: group2.id,
     })
     await app.service(SERVICES.CORE_USERGROUP).create({
@@ -336,11 +336,11 @@ export function builderTestEnvironment(prefix: string) {
       groupId: group3.id,
     })
     await app.service(SERVICES.CORE_USERGROUP).create({
-      userId: user4.id,
+      userId: userCreator4.id,
       groupId: group4.id,
     })
 
-    user1Authentication = await app.service(SERVICES.AUTH_AUTHENTICATION).create(
+    userCreator1Authentication = await app.service(SERVICES.AUTH_AUTHENTICATION).create(
       {
         strategy: 'local',
         email: `${prefix}abilities-user1@locokit.io`,
@@ -364,7 +364,7 @@ export function builderTestEnvironment(prefix: string) {
       },
       {},
     )
-    user4Authentication = await app.service(SERVICES.AUTH_AUTHENTICATION).create(
+    userCreator4Authentication = await app.service(SERVICES.AUTH_AUTHENTICATION).create(
       {
         strategy: 'local',
         email: `${prefix}abilities-user4@locokit.io`,
@@ -388,7 +388,6 @@ export function builderTestEnvironment(prefix: string) {
       },
       {},
     )
-
     // // let user1: User
     // // let group1: Group
     // const singleSelectOption1UUID = '1efa77d0-c07a-4d3e-8677-2c19c6a26ecd'
@@ -566,7 +565,7 @@ export function builderTestEnvironment(prefix: string) {
     //   },
     // })
     // table1Workspace2 = await app.service('table').create({
-    //   text: 'table1 workspace2',
+    //   text: 'table1 privateWorkspace',
     //   database_id: database2.id,
     // })
     // columnTable1W2Ref = await app.service('column').create({
@@ -660,18 +659,18 @@ export function builderTestEnvironment(prefix: string) {
 
     _data = {
       publicWorkspaceId: publicWorkspace.id,
-      workspace2Id: workspace2.id,
-      user1,
+      privateWorkspaceId: privateWorkspace.id,
+      userCreator1,
       user2,
       user3,
-      user4,
+      userCreator4,
       user5,
       userAdmin,
       userBlocked,
-      user1Authentication,
+      userCreator1Authentication,
       user2Authentication,
       user3Authentication,
-      user4Authentication,
+      userCreator4Authentication,
       user5Authentication,
       userAdminAuthentication,
       group1,
@@ -722,11 +721,11 @@ export function builderTestEnvironment(prefix: string) {
       authenticated: true,
       authentication: userAdminAuthentication,
     })
-    await app.service(SERVICES.CORE_WORKSPACE).patch(workspace2.id, {
+    await app.service(SERVICES.CORE_WORKSPACE).patch(privateWorkspace.id, {
       softDeletedAt: new Date().toISOString(),
     })
 
-    await app.service(SERVICES.CORE_WORKSPACE).remove(workspace2.id, {
+    await app.service(SERVICES.CORE_WORKSPACE).remove(privateWorkspace.id, {
       user: userAdmin,
       authenticated: true,
       authentication: userAdminAuthentication,
@@ -737,10 +736,10 @@ export function builderTestEnvironment(prefix: string) {
     await app.service(SERVICES.CORE_USER).remove(userBlocked.id)
 
     await app.service(SERVICES.CORE_USER).remove(user5.id)
-    await app.service(SERVICES.CORE_USER).remove(user4.id)
+    await app.service(SERVICES.CORE_USER).remove(userCreator4.id)
     await app.service(SERVICES.CORE_USER).remove(user3.id)
     await app.service(SERVICES.CORE_USER).remove(user2.id)
-    await app.service(SERVICES.CORE_USER).remove(user1.id)
+    await app.service(SERVICES.CORE_USER).remove(userCreator1.id)
 
     // console.log('teardown users OK')
     console.log('teardown OK')

--- a/api/src/configure.test.ts
+++ b/api/src/configure.test.ts
@@ -20,6 +20,8 @@ import { WorkspaceResult } from './services/core/workspace/workspace.schema'
 import { GroupResult } from './services/core/group/group.schema'
 import { PolicyResult } from './client'
 
+import { seed as resetDB } from '../seeds/test'
+
 const app = createApp()
 
 export interface SetupData {
@@ -155,6 +157,11 @@ export function builderTestEnvironment(prefix: string) {
      * We just return it.
      */
     if (_data) return _data
+
+    /**
+     * Reset the DB
+     */
+    resetDB(app.get('db'))
 
     /**
      * 1 Creating users first

--- a/api/src/feathers-objection/adapter.ts
+++ b/api/src/feathers-objection/adapter.ts
@@ -479,6 +479,11 @@ export class ObjectionAdapter<
      */
 
     const { table, id } = this
+    const idColumns = []
+    if (Array.isArray(id)) {
+      id.forEach((currentId: string) => idColumns.push(`${table}.${currentId}`))
+    } else idColumns.push(`${table}.${id}`)
+
     const { filters, query } = this.filterQuery(params)
     // const q = this._createQuery(params).skipUndefined()
     const builder = this.db(params)
@@ -492,7 +497,7 @@ export class ObjectionAdapter<
     // $select uses a specific find syntax, so it has to come first.
     if (filters.$select) {
       // always select the id field, but make sure we only select it once
-      builder.select(...new Set([...filters.$select, `${table}.${id}`]))
+      builder.select(...new Set([...filters.$select, ...idColumns]))
     } else {
       builder.select(`${table}.*`)
     }

--- a/api/src/hooks/locokit/index.ts
+++ b/api/src/hooks/locokit/index.ts
@@ -131,10 +131,7 @@ export async function setLocoKitContext(context: HookContext) {
 
         break
       case SERVICES.WORKSPACE_TABLE_FIELD:
-        locokitContextLogger.debug(
-          'workspace table field service found (method %s)',
-          context.method,
-        )
+        locokitContextLogger.info('workspace table field service found (method %s)', context.method)
         switch (context.method) {
           /**
            * We know the tableId,
@@ -167,7 +164,7 @@ export async function setLocoKitContext(context: HookContext) {
         }
         break
       case SERVICES.WORKSPACE_TABLE_RELATION:
-        locokitContextLogger.debug(
+        locokitContextLogger.info(
           'workspace table relation service found (method %s)',
           context.method,
         )

--- a/api/src/hooks/profile.hooks.test.ts
+++ b/api/src/hooks/profile.hooks.test.ts
@@ -7,7 +7,6 @@ import {
 } from './profile.hooks'
 import { USER_PROFILE } from '@locokit/definitions'
 import { HookContext } from '@/declarations'
-import { error } from 'console'
 
 describe('[hooks] profile', () => {
   describe('isUserProfile', () => {

--- a/api/src/hooks/profile.hooks.test.ts
+++ b/api/src/hooks/profile.hooks.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest'
+import {
+  checkInternalCallOrSpecificProfile,
+  isAdminProfile,
+  isInternalCallOrInternalAndAdminProfile,
+  isUserProfile,
+} from './profile.hooks'
+import { USER_PROFILE } from '@locokit/definitions'
+import { HookContext } from '@/declarations'
+import { error } from 'console'
+
+describe('[hooks] profile', () => {
+  describe('isUserProfile', () => {
+    it('return true if user has the right profile', () => {
+      expect.assertions(1)
+      const context: Partial<HookContext> = {
+        params: {
+          user: {
+            profile: USER_PROFILE.CREATOR,
+          },
+        },
+      }
+      const result = isUserProfile([USER_PROFILE.CREATOR])(context as HookContext)
+      expect(result).toBe(true)
+    })
+    it('return false if user has not the right profile', () => {
+      expect.assertions(1)
+      const context: Partial<HookContext> = {
+        params: {
+          user: {
+            profile: USER_PROFILE.MEMBER,
+          },
+        },
+      }
+      const result = isUserProfile([USER_PROFILE.CREATOR])(context as HookContext)
+      expect(result).toBe(false)
+    })
+  })
+  describe('isAdminProfile', () => {
+    it('return true if user has the right profile', () => {
+      expect.assertions(1)
+      const context: Partial<HookContext> = {
+        params: {
+          user: {
+            profile: USER_PROFILE.ADMIN,
+          },
+        },
+      }
+      const result = isAdminProfile(context as HookContext)
+      expect(result).toBe(true)
+    })
+    it('return false if user has not the right profile', () => {
+      expect.assertions(1)
+      const context: Partial<HookContext> = {
+        params: {
+          user: {
+            profile: USER_PROFILE.CREATOR,
+          },
+        },
+      }
+      const result = isAdminProfile(context as HookContext)
+      expect(result).toBe(false)
+    })
+  })
+  describe('checkInternalCallOrSpecificProfile', () => {
+    it('return the context if user has the right profile', () => {
+      expect.assertions(2)
+      const context: Partial<HookContext> = {
+        params: {
+          provider: 'external',
+          user: {
+            profile: USER_PROFILE.CREATOR,
+          },
+        },
+      }
+      const result = checkInternalCallOrSpecificProfile([USER_PROFILE.CREATOR])(
+        context as HookContext,
+      )
+      expect(result).toBeDefined()
+      expect(result).toBe(context)
+    })
+    it('throw an error if user has not the right profile', () => {
+      expect.assertions(3)
+      const context: Partial<HookContext> = {
+        params: {
+          provider: 'external',
+          user: {
+            profile: USER_PROFILE.ADMIN,
+          },
+        },
+      }
+      try {
+        checkInternalCallOrSpecificProfile([USER_PROFILE.CREATOR])(context as HookContext)
+      } catch (error) {
+        expect(error).toBeDefined()
+        const errorTyped = error as { code: number; className: string }
+        expect(errorTyped.code).toBe(403)
+        expect(errorTyped.className).toBe('forbidden')
+      }
+    })
+    it("return the context if it's an internal call", () => {
+      expect.assertions(2)
+      const context: Partial<HookContext> = {
+        params: {},
+      }
+      const result = checkInternalCallOrSpecificProfile([USER_PROFILE.CREATOR])(
+        context as HookContext,
+      )
+      expect(result).toBeDefined()
+      expect(result).toBe(context)
+    })
+    it('throw an error if internal call and user does not have the right profile', () => {
+      expect.assertions(3)
+      const context: Partial<HookContext> = {
+        params: {
+          user: {
+            profile: USER_PROFILE.CREATOR,
+          },
+        },
+      }
+      try {
+        checkInternalCallOrSpecificProfile([USER_PROFILE.ADMIN])(context as HookContext)
+      } catch (error) {
+        expect(error).toBeDefined()
+        const errorTyped = error as { code: number; className: string }
+        expect(errorTyped.code).toBe(403)
+        expect(errorTyped.className).toBe('forbidden')
+      }
+    })
+  })
+  describe('isInternalCallOrInternalAndAdminProfile', () => {
+    it('return the context if user has the right profile', () => {
+      expect.assertions(2)
+      const context: Partial<HookContext> = {
+        params: {
+          provider: 'external',
+          user: {
+            profile: USER_PROFILE.ADMIN,
+          },
+        },
+      }
+      const result = isInternalCallOrInternalAndAdminProfile(context as HookContext)
+      expect(result).toBeDefined()
+      expect(result).toBe(context)
+    })
+    it('throw an error if user has not the right profile', () => {
+      expect.assertions(3)
+      const context: Partial<HookContext> = {
+        params: {
+          provider: 'external',
+          user: {
+            profile: USER_PROFILE.CREATOR,
+          },
+        },
+      }
+      try {
+        isInternalCallOrInternalAndAdminProfile(context as HookContext)
+      } catch (error) {
+        expect(error).toBeDefined()
+        const errorTyped = error as { code: number; className: string }
+        expect(errorTyped.code).toBe(403)
+        expect(errorTyped.className).toBe('forbidden')
+      }
+    })
+    it("return the context if it's an internal call", () => {
+      expect.assertions(2)
+      const context: Partial<HookContext> = {
+        params: {},
+      }
+      const result = isInternalCallOrInternalAndAdminProfile(context as HookContext)
+      expect(result).toBeDefined()
+      expect(result).toBe(context)
+    })
+    it('throw an error if internal call and user does not have the right profile', () => {
+      expect.assertions(3)
+      const context: Partial<HookContext> = {
+        params: {
+          user: {
+            profile: USER_PROFILE.CREATOR,
+          },
+        },
+      }
+      try {
+        isInternalCallOrInternalAndAdminProfile(context as HookContext)
+      } catch (error) {
+        expect(error).toBeDefined()
+        const errorTyped = error as { code: number; className: string }
+        expect(errorTyped.code).toBe(403)
+        expect(errorTyped.className).toBe('forbidden')
+      }
+    })
+  })
+})

--- a/api/src/hooks/profile.hooks.test.ts
+++ b/api/src/hooks/profile.hooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   checkUserHasProfile,
-  checkProviderInternal,
+  checkProviderIsInternal,
   checkUserHasAccess,
   checkUserIsAdmin,
 } from './profile.hooks'
@@ -9,7 +9,7 @@ import { USER_PROFILE } from '@locokit/definitions'
 import { HookContext } from '@/declarations'
 
 describe('[hooks] profile', () => {
-  describe('checkProviderInternal', () => {
+  describe('checkProviderIsInternal', () => {
     it('return false if external call', () => {
       expect.assertions(1)
       const context: Partial<HookContext> = {
@@ -21,7 +21,7 @@ describe('[hooks] profile', () => {
         },
       }
 
-      expect(checkProviderInternal(context as HookContext)).toBe(false)
+      expect(checkProviderIsInternal(context as HookContext)).toBe(false)
     })
     it('return true if internal call', () => {
       expect.assertions(1)
@@ -32,7 +32,7 @@ describe('[hooks] profile', () => {
           },
         },
       }
-      expect(checkProviderInternal(context as HookContext)).toBe(true)
+      expect(checkProviderIsInternal(context as HookContext)).toBe(true)
     })
   })
   describe('checkUserHasProfile', () => {
@@ -123,7 +123,7 @@ describe('[hooks] profile', () => {
         },
       }
       const result = checkUserHasAccess({
-        userProfile: [USER_PROFILE.CREATOR],
+        allowedProfile: [USER_PROFILE.CREATOR],
         internalProvider: true,
       })(context as HookContext)
       expect(result).toBeDefined()
@@ -141,7 +141,7 @@ describe('[hooks] profile', () => {
       }
       try {
         checkUserHasAccess({
-          userProfile: [USER_PROFILE.CREATOR],
+          allowedProfile: [USER_PROFILE.CREATOR],
           internalProvider: true,
         })(context as HookContext)
       } catch (error) {
@@ -157,7 +157,7 @@ describe('[hooks] profile', () => {
         params: {},
       }
       const result = checkUserHasAccess({
-        userProfile: [USER_PROFILE.CREATOR],
+        allowedProfile: [USER_PROFILE.CREATOR],
         internalProvider: true,
         internalProviderProfileCheck: false,
       })(context as HookContext)
@@ -175,7 +175,7 @@ describe('[hooks] profile', () => {
       }
       try {
         checkUserHasAccess({
-          userProfile: [USER_PROFILE.ADMIN],
+          allowedProfile: [USER_PROFILE.ADMIN],
           internalProvider: true,
           internalProviderProfileCheck: 'IF_USER_PROVIDED',
         })(context as HookContext)
@@ -197,7 +197,7 @@ describe('[hooks] profile', () => {
         },
       }
       const result = checkUserHasAccess({
-        userProfile: [USER_PROFILE.ADMIN],
+        allowedProfile: [USER_PROFILE.ADMIN],
         internalProvider: true,
         internalProviderProfileCheck: 'IF_USER_PROVIDED',
       })(context as HookContext)
@@ -216,7 +216,7 @@ describe('[hooks] profile', () => {
       }
       try {
         checkUserHasAccess({
-          userProfile: [USER_PROFILE.ADMIN],
+          allowedProfile: [USER_PROFILE.ADMIN],
           internalProvider: true,
           internalProviderProfileCheck: 'IF_USER_PROVIDED',
         })(context as HookContext)
@@ -233,7 +233,7 @@ describe('[hooks] profile', () => {
         params: {},
       }
       const result = checkUserHasAccess({
-        userProfile: [USER_PROFILE.ADMIN],
+        allowedProfile: [USER_PROFILE.ADMIN],
         internalProvider: true,
         internalProviderProfileCheck: 'IF_USER_PROVIDED',
       })(context as HookContext)
@@ -251,7 +251,7 @@ describe('[hooks] profile', () => {
       }
       try {
         checkUserHasAccess({
-          userProfile: [USER_PROFILE.ADMIN],
+          allowedProfile: [USER_PROFILE.ADMIN],
           internalProvider: true,
           internalProviderProfileCheck: 'IF_USER_PROVIDED',
         })(context as HookContext)

--- a/api/src/hooks/profile.hooks.test.ts
+++ b/api/src/hooks/profile.hooks.test.ts
@@ -1,15 +1,41 @@
 import { describe, it, expect } from 'vitest'
 import {
-  checkInternalCallOrSpecificProfile,
-  isAdminProfile,
-  isInternalCallOrInternalAndAdminProfile,
-  isUserProfile,
+  checkUserHasProfile,
+  checkProviderInternal,
+  checkUserHasAccess,
+  checkUserIsAdmin,
 } from './profile.hooks'
 import { USER_PROFILE } from '@locokit/definitions'
 import { HookContext } from '@/declarations'
 
 describe('[hooks] profile', () => {
-  describe('isUserProfile', () => {
+  describe('checkProviderInternal', () => {
+    it('return false if external call', () => {
+      expect.assertions(1)
+      const context: Partial<HookContext> = {
+        params: {
+          provider: 'external',
+          user: {
+            profile: USER_PROFILE.CREATOR,
+          },
+        },
+      }
+
+      expect(checkProviderInternal(context as HookContext)).toBe(false)
+    })
+    it('return true if internal call', () => {
+      expect.assertions(1)
+      const context: Partial<HookContext> = {
+        params: {
+          user: {
+            profile: USER_PROFILE.MEMBER,
+          },
+        },
+      }
+      expect(checkProviderInternal(context as HookContext)).toBe(true)
+    })
+  })
+  describe('checkUserHasProfile', () => {
     it('return true if user has the right profile', () => {
       expect.assertions(1)
       const context: Partial<HookContext> = {
@@ -19,7 +45,7 @@ describe('[hooks] profile', () => {
           },
         },
       }
-      const result = isUserProfile([USER_PROFILE.CREATOR])(context as HookContext)
+      const result = checkUserHasProfile([USER_PROFILE.CREATOR], context as HookContext)
       expect(result).toBe(true)
     })
     it('return false if user has not the right profile', () => {
@@ -31,12 +57,10 @@ describe('[hooks] profile', () => {
           },
         },
       }
-      const result = isUserProfile([USER_PROFILE.CREATOR])(context as HookContext)
+      const result = checkUserHasProfile([USER_PROFILE.CREATOR], context as HookContext)
       expect(result).toBe(false)
     })
-  })
-  describe('isAdminProfile', () => {
-    it('return true if user has the right profile', () => {
+    it('return true if user has the ADMIN profile', () => {
       expect.assertions(1)
       const context: Partial<HookContext> = {
         params: {
@@ -45,10 +69,10 @@ describe('[hooks] profile', () => {
           },
         },
       }
-      const result = isAdminProfile(context as HookContext)
+      const result = checkUserHasProfile([USER_PROFILE.ADMIN], context as HookContext)
       expect(result).toBe(true)
     })
-    it('return false if user has not the right profile', () => {
+    it('return false if user has not the ADMIN profile', () => {
       expect.assertions(1)
       const context: Partial<HookContext> = {
         params: {
@@ -57,59 +81,25 @@ describe('[hooks] profile', () => {
           },
         },
       }
-      const result = isAdminProfile(context as HookContext)
+      const result = checkUserHasProfile([USER_PROFILE.ADMIN], context as HookContext)
       expect(result).toBe(false)
     })
   })
-  describe('checkInternalCallOrSpecificProfile', () => {
-    it('return the context if user has the right profile', () => {
-      expect.assertions(2)
+  describe('checkUserIsAdmin', () => {
+    it('return true if user has the ADMIN profile', () => {
+      expect.assertions(1)
       const context: Partial<HookContext> = {
         params: {
-          provider: 'external',
-          user: {
-            profile: USER_PROFILE.CREATOR,
-          },
-        },
-      }
-      const result = checkInternalCallOrSpecificProfile([USER_PROFILE.CREATOR])(
-        context as HookContext,
-      )
-      expect(result).toBeDefined()
-      expect(result).toBe(context)
-    })
-    it('throw an error if user has not the right profile', () => {
-      expect.assertions(3)
-      const context: Partial<HookContext> = {
-        params: {
-          provider: 'external',
           user: {
             profile: USER_PROFILE.ADMIN,
           },
         },
       }
-      try {
-        checkInternalCallOrSpecificProfile([USER_PROFILE.CREATOR])(context as HookContext)
-      } catch (error) {
-        expect(error).toBeDefined()
-        const errorTyped = error as { code: number; className: string }
-        expect(errorTyped.code).toBe(403)
-        expect(errorTyped.className).toBe('forbidden')
-      }
+      const result = checkUserIsAdmin(context as HookContext)
+      expect(result).toBe(true)
     })
-    it("return the context if it's an internal call", () => {
-      expect.assertions(2)
-      const context: Partial<HookContext> = {
-        params: {},
-      }
-      const result = checkInternalCallOrSpecificProfile([USER_PROFILE.CREATOR])(
-        context as HookContext,
-      )
-      expect(result).toBeDefined()
-      expect(result).toBe(context)
-    })
-    it('throw an error if internal call and user does not have the right profile', () => {
-      expect.assertions(3)
+    it('return false if user has not the ADMIN profile', () => {
+      expect.assertions(1)
       const context: Partial<HookContext> = {
         params: {
           user: {
@@ -117,17 +107,85 @@ describe('[hooks] profile', () => {
           },
         },
       }
-      try {
-        checkInternalCallOrSpecificProfile([USER_PROFILE.ADMIN])(context as HookContext)
-      } catch (error) {
-        expect(error).toBeDefined()
-        const errorTyped = error as { code: number; className: string }
-        expect(errorTyped.code).toBe(403)
-        expect(errorTyped.className).toBe('forbidden')
-      }
+      const result = checkUserIsAdmin(context as HookContext)
+      expect(result).toBe(false)
     })
   })
-  describe('isInternalCallOrInternalAndAdminProfile', () => {
+  describe('checkUserHasAccess', () => {
+    it('return the context if user has the right profile', () => {
+      expect.assertions(2)
+      const context: Partial<HookContext> = {
+        params: {
+          provider: 'external',
+          user: {
+            profile: USER_PROFILE.CREATOR,
+          },
+        },
+      }
+      const result = checkUserHasAccess({
+        userProfile: [USER_PROFILE.CREATOR],
+        internalProvider: true,
+      })(context as HookContext)
+      expect(result).toBeDefined()
+      expect(result).toBe(context)
+    })
+    it('throw an error if user has not the right profile', () => {
+      expect.assertions(3)
+      const context: Partial<HookContext> = {
+        params: {
+          provider: 'external',
+          user: {
+            profile: USER_PROFILE.ADMIN,
+          },
+        },
+      }
+      try {
+        checkUserHasAccess({
+          userProfile: [USER_PROFILE.CREATOR],
+          internalProvider: true,
+        })(context as HookContext)
+      } catch (error) {
+        expect(error).toBeDefined()
+        const errorTyped = error as { code: number; className: string }
+        expect(errorTyped.code).toBe(403)
+        expect(errorTyped.className).toBe('forbidden')
+      }
+    })
+    it("return the context if it's an internal call", () => {
+      expect.assertions(2)
+      const context: Partial<HookContext> = {
+        params: {},
+      }
+      const result = checkUserHasAccess({
+        userProfile: [USER_PROFILE.CREATOR],
+        internalProvider: true,
+        internalProviderProfileCheck: false,
+      })(context as HookContext)
+      expect(result).toBeDefined()
+      expect(result).toBe(context)
+    })
+    it('throw an error if internal call and user does not have the right profile', () => {
+      expect.assertions(3)
+      const context: Partial<HookContext> = {
+        params: {
+          user: {
+            profile: USER_PROFILE.CREATOR,
+          },
+        },
+      }
+      try {
+        checkUserHasAccess({
+          userProfile: [USER_PROFILE.ADMIN],
+          internalProvider: true,
+          internalProviderProfileCheck: 'IF_USER_PROVIDED',
+        })(context as HookContext)
+      } catch (error) {
+        expect(error).toBeDefined()
+        const errorTyped = error as { code: number; className: string }
+        expect(errorTyped.code).toBe(403)
+        expect(errorTyped.className).toBe('forbidden')
+      }
+    })
     it('return the context if user has the right profile', () => {
       expect.assertions(2)
       const context: Partial<HookContext> = {
@@ -138,7 +196,11 @@ describe('[hooks] profile', () => {
           },
         },
       }
-      const result = isInternalCallOrInternalAndAdminProfile(context as HookContext)
+      const result = checkUserHasAccess({
+        userProfile: [USER_PROFILE.ADMIN],
+        internalProvider: true,
+        internalProviderProfileCheck: 'IF_USER_PROVIDED',
+      })(context as HookContext)
       expect(result).toBeDefined()
       expect(result).toBe(context)
     })
@@ -153,7 +215,11 @@ describe('[hooks] profile', () => {
         },
       }
       try {
-        isInternalCallOrInternalAndAdminProfile(context as HookContext)
+        checkUserHasAccess({
+          userProfile: [USER_PROFILE.ADMIN],
+          internalProvider: true,
+          internalProviderProfileCheck: 'IF_USER_PROVIDED',
+        })(context as HookContext)
       } catch (error) {
         expect(error).toBeDefined()
         const errorTyped = error as { code: number; className: string }
@@ -166,7 +232,11 @@ describe('[hooks] profile', () => {
       const context: Partial<HookContext> = {
         params: {},
       }
-      const result = isInternalCallOrInternalAndAdminProfile(context as HookContext)
+      const result = checkUserHasAccess({
+        userProfile: [USER_PROFILE.ADMIN],
+        internalProvider: true,
+        internalProviderProfileCheck: 'IF_USER_PROVIDED',
+      })(context as HookContext)
       expect(result).toBeDefined()
       expect(result).toBe(context)
     })
@@ -180,7 +250,11 @@ describe('[hooks] profile', () => {
         },
       }
       try {
-        isInternalCallOrInternalAndAdminProfile(context as HookContext)
+        checkUserHasAccess({
+          userProfile: [USER_PROFILE.ADMIN],
+          internalProvider: true,
+          internalProviderProfileCheck: 'IF_USER_PROVIDED',
+        })(context as HookContext)
       } catch (error) {
         expect(error).toBeDefined()
         const errorTyped = error as { code: number; className: string }

--- a/api/src/hooks/profile.hooks.ts
+++ b/api/src/hooks/profile.hooks.ts
@@ -13,7 +13,7 @@ export function checkUserHasProfile(
   return profiles.includes(context.params.user?.profile as keyof typeof USER_PROFILE)
 }
 
-export function checkProviderInternal(context: HookContext): boolean {
+export function checkProviderIsInternal(context: HookContext): boolean {
   return !context.params.provider
   // if (!context.params.user || context.params.user.profile === USER_PROFILE.ADMIN) return true
 }
@@ -26,7 +26,7 @@ export const checkUserHasAccess =
     /**
      * which profile(s) is(are) needed
      */
-    userProfile: Array<keyof typeof USER_PROFILE> | keyof typeof USER_PROFILE
+    allowedProfile: Array<keyof typeof USER_PROFILE> | keyof typeof USER_PROFILE
     /**
      * is the call has to be an internal one ?
      */
@@ -38,8 +38,8 @@ export const checkUserHasAccess =
     internalProviderProfileCheck?: 'ALWAYS' | 'IF_USER_PROVIDED'
   }) =>
   (context: HookContext): HookContext => {
-    const userHasProfile = checkUserHasProfile(options.userProfile, context)
-    const isInternalProvider = checkProviderInternal(context)
+    const userHasProfile = checkUserHasProfile(options.allowedProfile, context)
+    const isInternalProvider = checkProviderIsInternal(context)
 
     if (!isInternalProvider && userHasProfile) return context
     if (options.internalProvider && isInternalProvider) {

--- a/api/src/hooks/profile.hooks.ts
+++ b/api/src/hooks/profile.hooks.ts
@@ -1,5 +1,5 @@
 import { USER_PROFILE } from '@locokit/definitions'
-import { PredicateFn } from 'feathers-hooks-common'
+import { HookFunction, SyncPredicateFn } from 'feathers-hooks-common'
 import { HookContext } from '../declarations'
 import { Forbidden } from '@feathersjs/errors'
 
@@ -9,41 +9,40 @@ import { Forbidden } from '@feathersjs/errors'
 export const isUserProfile =
   (
     profile: Array<keyof typeof USER_PROFILE> | keyof typeof USER_PROFILE,
-  ): PredicateFn<HookContext> =>
+  ): SyncPredicateFn<HookContext> =>
   (context: HookContext): boolean => {
     const profiles = Array.isArray(profile) ? profile : [profile]
-    const includeUserProfile = profiles.includes(
-      context.params.user?.profile as keyof typeof USER_PROFILE,
-    )
-    if (!includeUserProfile) throw new Error('User is not authorized to access this.')
-    return true
+    return profiles.includes(context.params.user?.profile as keyof typeof USER_PROFILE)
   }
 
 /**
  * Check if the user has a ADMIN profile
  */
-// export const isAdminProfile: PredicateFn = isUserProfile(USER_PROFILE.ADMIN)
-
 export const isAdminProfile = (context: HookContext): boolean => {
-  return context.params.user?.profile === USER_PROFILE.ADMIN
+  return isUserProfile(USER_PROFILE.ADMIN)(context)
 }
+
+/**
+ * Let internal calls pass OR user with specific profile
+ */
+export const checkInternalCallOrSpecificProfile =
+  (
+    profile: Array<keyof typeof USER_PROFILE> | keyof typeof USER_PROFILE = [USER_PROFILE.ADMIN],
+  ): HookFunction<HookContext> =>
+  (context: HookContext): HookContext => {
+    const hasSpecificProfile = isUserProfile(profile)(context)
+    if (hasSpecificProfile) return context
+
+    if (!context.params.provider) {
+      if (!context.params.user || context.params.user.profile === USER_PROFILE.ADMIN) return context
+    }
+
+    throw new Forbidden("You can't access this service.")
+  }
 
 /**
  * Check if the call is internal and the user is an ADMIN one
  */
-export async function isInternalCallOrInternalAndAdminProfile(context: HookContext) {
-  /**
-   * Let ADMIN user pass
-   */
-  if (context.params.user?.profile === USER_PROFILE.ADMIN) return context
-
-  /**
-   * Let the user pass if it's an internal call
-   * and the logged user is an admin one
-   */
-  if (!context.params.provider) {
-    if (!context.params.user || context.params.user.profile === USER_PROFILE.ADMIN) return context
-  }
-
-  throw new Forbidden("You can't access this service.")
+export function isInternalCallOrInternalAndAdminProfile(context: HookContext) {
+  return checkInternalCallOrSpecificProfile([USER_PROFILE.ADMIN])(context)
 }

--- a/api/src/hooks/profile.hooks.ts
+++ b/api/src/hooks/profile.hooks.ts
@@ -1,6 +1,7 @@
 import { USER_PROFILE } from '@locokit/definitions'
 import { PredicateFn } from 'feathers-hooks-common'
 import { HookContext } from '../declarations'
+import { Forbidden } from '@feathersjs/errors'
 
 /**
  * Check if a user profile match a listing of PROFILE
@@ -25,4 +26,24 @@ export const isUserProfile =
 
 export const isAdminProfile = (context: HookContext): boolean => {
   return context.params.user?.profile === USER_PROFILE.ADMIN
+}
+
+/**
+ * Check if the call is internal and the user is an ADMIN one
+ */
+export async function isInternalCallOrInternalAndAdminProfile(context: HookContext) {
+  /**
+   * Let ADMIN user pass
+   */
+  if (context.params.user?.profile === USER_PROFILE.ADMIN) return context
+
+  /**
+   * Let the user pass if it's an internal call
+   * and the logged user is an admin one
+   */
+  if (!context.params.provider) {
+    if (!context.params.user || context.params.user.profile === USER_PROFILE.ADMIN) return context
+  }
+
+  throw new Forbidden("You can't access this service.")
 }

--- a/api/src/services/auth/authentication/authentication.abilities.ts
+++ b/api/src/services/auth/authentication/authentication.abilities.ts
@@ -1,12 +1,12 @@
-import { AbilityBuilder, AnyMongoAbility } from '@casl/ability'
+import { AbilityBuilder, createMongoAbility } from '@casl/ability'
 import { USER_PROFILE } from '@locokit/definitions'
-import { AppAbility, resolveAction } from '../../../abilities/definitions'
-import makeAbilityFromRules from '../../../abilities/makeAbilityFromRules'
+import { resolveAction } from '@/abilities/definitions'
 import { UserResult } from '@/services/core/user/user.schema'
+import { HookContext } from '@feathersjs/feathers'
 
-export function defineAbilities(user: UserResult): AnyMongoAbility {
+export function getAbility(user: UserResult) {
   // also see https://casl.js.org/v5/en/guide/define-rules
-  const { can, rules } = new AbilityBuilder(AppAbility)
+  const { can, build } = new AbilityBuilder(createMongoAbility)
 
   /**
    * TODO: add public rules for anonymous (e.g., read public workspaces ?)
@@ -31,5 +31,16 @@ export function defineAbilities(user: UserResult): AnyMongoAbility {
       break
   }
 
-  return makeAbilityFromRules(rules, { resolveAction })
+  return build({ resolveAction })
+}
+
+export function defineRules(context: HookContext) {
+  if (!context.params.provider) return context
+
+  const ability = getAbility(context.params.user as UserResult)
+
+  context.params.ability = ability
+  context.params.rules = ability.rules
+
+  return context
 }

--- a/api/src/services/auth/authentication/authentication.abilities.ts
+++ b/api/src/services/auth/authentication/authentication.abilities.ts
@@ -34,7 +34,7 @@ export function getAbility(user: UserResult) {
   return build({ resolveAction })
 }
 
-export function defineRules(context: HookContext) {
+export function setAbilities(context: HookContext) {
   if (!context.params.provider) return context
 
   const ability = getAbility(context.params.user as UserResult)

--- a/api/src/services/auth/authentication/authentication.hooks.ts
+++ b/api/src/services/auth/authentication/authentication.hooks.ts
@@ -1,6 +1,6 @@
 import { Forbidden } from '@feathersjs/errors'
 import { HookContext } from '@/declarations'
-import { defineRules } from './authentication.abilities'
+import { setAbilities } from './authentication.abilities'
 
 // Don't remove this comment. It's needed to format import lines nicely.
 
@@ -37,7 +37,7 @@ export const hooks = {
       //   delete rec.user.resetAttempts
       //   console.log('alterItems', rec)
       // }),
-      defineRules,
+      setAbilities,
       addRulesToUser,
     ],
   },

--- a/api/src/services/auth/authentication/authentication.hooks.ts
+++ b/api/src/services/auth/authentication/authentication.hooks.ts
@@ -1,11 +1,6 @@
 import { Forbidden } from '@feathersjs/errors'
-// import { alterItems } from 'feathers-hooks-common'
-import { USER_PROFILE } from '@locokit/definitions'
-import { AbilityBuilder } from '@casl/ability'
-
-import { AppAbility, resolveAction } from '@/abilities/definitions'
 import { HookContext } from '@/declarations'
-import makeAbilityFromRules from '@/abilities/makeAbilityFromRules'
+import { defineRules } from './authentication.abilities'
 
 // Don't remove this comment. It's needed to format import lines nicely.
 
@@ -15,56 +10,6 @@ export async function addRulesToUser(context: HookContext): Promise<HookContext>
   if (!user) return context
   context.result.user.rules = context.params.rules
   // console.log('add rules to user', context.params, context.result.user)
-  return context
-}
-
-/**
- * Define abilities for entities, high level one.
- * For more grained, we need to go deeper in each service
- *
- * @param context Hook context, provided by FeathersJS
- * @returns Promise<HookContext>
- */
-async function defineAbilities(context: HookContext): Promise<HookContext> {
-  // also see https://casl.js.org/v5/en/guide/define-rules
-  const { can, rules } = new AbilityBuilder(AppAbility)
-  const { user } = context.result
-
-  /**
-   * TODO: add public rules for anonymous (e.g., read public workspaces ?)
-   */
-  switch (user?.profile) {
-    case USER_PROFILE.ADMIN:
-      can('manage', 'all')
-      break
-    case USER_PROFILE.CREATOR:
-      can('create', 'workspace')
-      can('read', 'workspace')
-      can('manage', 'user', { id: user.id })
-      break
-    /**
-     * User connected can
-     * * find their groups
-     * * find workspace of their groups
-     */
-    case USER_PROFILE.MEMBER:
-      can('read', 'workspace')
-      can('manage', 'user', { id: user.id })
-      break
-    /**
-     * No profile,
-     * anonymous can read public workspace
-     */
-    default:
-      can('read', 'workspace', { public: true })
-      break
-  }
-
-  const ability = makeAbilityFromRules(rules, { resolveAction })
-  // console.log(ability, ability.rules, rules)
-  context.params.ability = ability
-  context.params.rules = ability.rules
-
   return context
 }
 
@@ -92,7 +37,7 @@ export const hooks = {
       //   delete rec.user.resetAttempts
       //   console.log('alterItems', rec)
       // }),
-      defineAbilities,
+      defineRules,
       addRulesToUser,
     ],
   },

--- a/api/src/services/auth/authentication/authentication.test.ts
+++ b/api/src/services/auth/authentication/authentication.test.ts
@@ -29,8 +29,8 @@ describe('authentication', () => {
   })
 
   afterAll(async () => {
-    await app.teardown()
     await builder.teardownWorkspace()
+    await app.teardown()
   })
 
   beforeEach(async () => {

--- a/api/src/services/auth/authentication/authentication.test.ts
+++ b/api/src/services/auth/authentication/authentication.test.ts
@@ -103,4 +103,6 @@ describe('authentication', () => {
   it.todo(
     'can work in local strategy with the couple username/password too instead of email/password',
   )
+
+  it.todo('restrict fields returned to the user, like sensitive data')
 })

--- a/api/src/services/auth/authentication/jwt.strategy.ts
+++ b/api/src/services/auth/authentication/jwt.strategy.ts
@@ -7,7 +7,7 @@ import { AnyMongoAbility } from '@casl/ability'
 
 import { UserResult } from '@/services/core/user/user.schema'
 import { logger } from '@/logger'
-import { defineAbilities } from './authentication.abilities'
+import { getAbility } from './authentication.abilities'
 
 const jwtLogger = logger.child({ service: 'authentication-jwt-enhanced' })
 
@@ -42,7 +42,7 @@ export class JWTStrategyEnhanced extends JWTStrategy {
     }
     const result = {
       ...superResult,
-      ability: defineAbilities(superResult.user) as AnyMongoAbility,
+      ability: getAbility(superResult.user) as AnyMongoAbility,
     }
     return result
   }

--- a/api/src/services/core/datasource/datasource.hooks.ts
+++ b/api/src/services/core/datasource/datasource.hooks.ts
@@ -11,7 +11,7 @@ export const coreDatasourceHooks = {
   before: {
     all: [
       checkUserHasAccess({
-        userProfile: [USER_PROFILE.ADMIN],
+        allowedProfile: [USER_PROFILE.ADMIN],
         internalProvider: true,
         internalProviderProfileCheck: 'IF_USER_PROVIDED',
       }),

--- a/api/src/services/core/datasource/datasource.hooks.ts
+++ b/api/src/services/core/datasource/datasource.hooks.ts
@@ -13,7 +13,7 @@ export const coreDatasourceHooks = {
       checkUserHasAccess({
         userProfile: [USER_PROFILE.ADMIN],
         internalProvider: true,
-        internalProviderProfileCheck: 'ALWAYS',
+        internalProviderProfileCheck: 'IF_USER_PROVIDED',
       }),
       transaction.start(),
     ],

--- a/api/src/services/core/datasource/datasource.hooks.ts
+++ b/api/src/services/core/datasource/datasource.hooks.ts
@@ -1,30 +1,14 @@
 import { authenticate } from '@feathersjs/authentication'
 import { transaction } from '@/feathers-objection'
-import { HookContext } from '@/declarations'
-import { USER_PROFILE } from '@locokit/definitions'
-import { Forbidden } from '@feathersjs/errors/lib'
 import { disallow } from 'feathers-hooks-common'
+import { isInternalCallOrInternalAndAdminProfile } from '@/hooks/profile.hooks'
 
 export const coreDatasourceHooks = {
   around: {
     all: [authenticate('jwt')],
   },
   before: {
-    all: [
-      async function checkProfile(context: HookContext) {
-        /**
-         * Check the user is an admin one
-         */
-        if (context.params.user && context.params.user.profile !== USER_PROFILE.ADMIN)
-          throw new Forbidden("You can't access datasources.")
-
-        /**
-         * Let the user pass if it's an internal call
-         */
-        if (!context.params.provider) return context
-      },
-      transaction.start(),
-    ],
+    all: [isInternalCallOrInternalAndAdminProfile, transaction.start()],
     create: [disallow()],
     update: [disallow()],
     remove: [disallow()],

--- a/api/src/services/core/datasource/datasource.hooks.ts
+++ b/api/src/services/core/datasource/datasource.hooks.ts
@@ -1,14 +1,22 @@
 import { authenticate } from '@feathersjs/authentication'
 import { transaction } from '@/feathers-objection'
 import { disallow } from 'feathers-hooks-common'
-import { isInternalCallOrInternalAndAdminProfile } from '@/hooks/profile.hooks'
+import { checkUserHasAccess } from '@/hooks/profile.hooks'
+import { USER_PROFILE } from '@locokit/definitions'
 
 export const coreDatasourceHooks = {
   around: {
     all: [authenticate('jwt')],
   },
   before: {
-    all: [isInternalCallOrInternalAndAdminProfile, transaction.start()],
+    all: [
+      checkUserHasAccess({
+        userProfile: [USER_PROFILE.ADMIN],
+        internalProvider: true,
+        internalProviderProfileCheck: 'ALWAYS',
+      }),
+      transaction.start(),
+    ],
     create: [disallow()],
     update: [disallow()],
     remove: [disallow()],

--- a/api/src/services/core/datasource/datasource.shared.ts
+++ b/api/src/services/core/datasource/datasource.shared.ts
@@ -8,7 +8,7 @@ export type DatasourceClientService = Pick<DatasourceService, (typeof datasource
 
 export const datasourcePath = SERVICES.CORE_DATASOURCE
 
-export const datasourceMethods = ['find', 'get', 'patch'] as const
+export const datasourceMethods = ['find', 'get'] as const
 
 export const datasourceClient = (client: ClientApplication) => {
   const connection = client.get('connection')

--- a/api/src/services/core/datasource/datasource.test.ts
+++ b/api/src/services/core/datasource/datasource.test.ts
@@ -158,6 +158,18 @@ describe('[core] datasource service', () => {
       expect(datasource.id).toBe(forbidDatasource.id)
     })
 
+    it('allow external calls for ADMIN users', async () => {
+      expect.assertions(2)
+      const datasource = await app.service(SERVICES.CORE_DATASOURCE).get(forbidDatasource.id, {
+        provider: 'external',
+        authenticated: true,
+        user: setupData.userAdmin,
+        authentication: setupData.userAdminAuthentication,
+      })
+      expect(datasource).toBeDefined()
+      expect(datasource.id).toBe(forbidDatasource.id)
+    })
+
     afterAll(async () => {
       await app.service(SERVICES.WORKSPACE_DATASOURCE).remove(forbidDatasource.id)
     })

--- a/api/src/services/core/datasource/datasource.test.ts
+++ b/api/src/services/core/datasource/datasource.test.ts
@@ -8,7 +8,7 @@ import { Forbidden, MethodNotAllowed } from '@feathersjs/errors/lib'
 
 describe('[core] datasource service', () => {
   const app = createApp()
-  const builder = builderTestEnvironment('core-workspace')
+  const builder = builderTestEnvironment('core-datasource')
   let setupData: SetupData
   const port = app.get('port') || 8998
   // const getUrl = (pathname: string) =>

--- a/api/src/services/core/datasource/datasource.test.ts
+++ b/api/src/services/core/datasource/datasource.test.ts
@@ -23,7 +23,7 @@ describe('[core] datasource service', () => {
 
     workspace = await app.service(SERVICES.CORE_WORKSPACE).create({
       name: 'Testing workspace datasource',
-      createdBy: setupData.user1.id,
+      createdBy: setupData.userCreator1.id,
     })
   })
 
@@ -130,8 +130,8 @@ describe('[core] datasource service', () => {
         app.service(SERVICES.CORE_DATASOURCE).get(forbidDatasource.id, {
           provider: 'external',
           authenticated: true,
-          user: setupData.user1,
-          authentication: setupData.user1Authentication,
+          user: setupData.userCreator1,
+          authentication: setupData.userCreator1Authentication,
         }),
       ).rejects.toThrowError(Forbidden)
     })
@@ -141,8 +141,8 @@ describe('[core] datasource service', () => {
       await expect(
         app.service(SERVICES.CORE_DATASOURCE).get(forbidDatasource.id, {
           authenticated: true,
-          user: setupData.user1,
-          authentication: setupData.user1Authentication,
+          user: setupData.userCreator1,
+          authentication: setupData.userCreator1Authentication,
         }),
       ).rejects.toThrowError(Forbidden)
     })

--- a/api/src/services/core/group/group.ability.ts
+++ b/api/src/services/core/group/group.ability.ts
@@ -16,7 +16,7 @@ import { resolveAction } from '@/abilities/definitions'
  * * ADMIN profiles : OK
  * * CREATOR profiles : filter on workspaceId $in [workspace they created]
  */
-export const defineRules = async (context: HookContext) => {
+export const setAbilities = async (context: HookContext) => {
   if (!context.params.provider) return context
   const { app } = context
 

--- a/api/src/services/core/group/group.ability.ts
+++ b/api/src/services/core/group/group.ability.ts
@@ -1,0 +1,98 @@
+import { HookContext } from '@/declarations'
+import { SERVICES, USER_PROFILE } from '@locokit/definitions'
+import { AbilityBuilder, createMongoAbility } from '@casl/ability'
+import { UserResult } from '../user/user.schema'
+import { resolveAction } from '@/abilities/definitions'
+
+/**
+ * /core/group
+ *
+ * READ
+ * * ADMIN profiles : all groups
+ * * CREATOR / MEMBER : their groups
+ *
+ * CREATE / UPDATE / DELETE
+ * * forbidden for MEMBER profiles
+ * * ADMIN profiles : OK
+ * * CREATOR profiles : filter on workspaceId $in [workspace they created]
+ */
+export const defineRules = async (context: HookContext) => {
+  if (!context.params.provider) return context
+  const { app } = context
+
+  const user = context.params.user as UserResult
+  const { can, cannot, build } = new AbilityBuilder(createMongoAbility)
+
+  const userProfile: keyof typeof USER_PROFILE = user?.profile
+
+  switch (userProfile) {
+    case USER_PROFILE.MEMBER:
+      /**
+       * can only read their groups
+       */
+      const memberGroupsId = (
+        await app.service(SERVICES.CORE_USERGROUP).find({
+          query: {
+            $select: ['groupId'],
+            userId: user.id,
+          },
+          paginate: false,
+        })
+      ).map((ug) => ug.groupId)
+      can('read', 'core/group', {
+        id: {
+          $in: memberGroupsId,
+        },
+      })
+      cannot(['update', 'delete'], 'core/group')
+
+      break
+    case USER_PROFILE.CREATOR:
+      /**
+       * can access only to their groups
+       */
+      const creatorGroupsId = (
+        await app.service(SERVICES.CORE_USERGROUP).find({
+          query: {
+            $select: ['groupId'],
+            userId: user.id,
+          },
+          paginate: false,
+        })
+      ).map((ug) => ug.groupId)
+      can('read', 'core/group', {
+        id: {
+          $in: creatorGroupsId,
+        },
+      })
+      /**
+       * but can create / update / delete related groups of their workspaces
+       */
+      const userWorkspacesId = (
+        await app.service(SERVICES.CORE_WORKSPACE).find({
+          query: {
+            $select: ['id'],
+            createdBy: user.id,
+          },
+          paginate: false,
+        })
+      ).map((w) => w.id)
+      can('manage', 'core/group', {
+        workspaceId: {
+          $in: userWorkspacesId,
+        },
+      })
+      break
+    case USER_PROFILE.ADMIN:
+      /**
+       * can manage all groups
+       */
+      can('manage', 'core/group')
+  }
+
+  const ability = build({ resolveAction })
+  context.params.ability = ability
+  context.params.rules = ability.rules
+
+  return context
+}

--- a/api/src/services/core/group/group.class.ts
+++ b/api/src/services/core/group/group.class.ts
@@ -17,6 +17,12 @@ import { groupResolvers } from './group.resolver'
 import { authenticate } from '@feathersjs/authentication'
 import { UserResult } from '../user/user.schema'
 
+import { setAbilities } from './group.ability'
+import { authorize } from 'feathers-casl'
+import { Forbidden } from '@feathersjs/errors'
+import { USER_PROFILE } from '@locokit/definitions'
+
+const authorizeHook = authorize({ adapter: '@feathersjs/knex' })
 async function checkProfile(context: HookContext) {
   const user: UserResult = context.params.user
   const profile = user.profile
@@ -24,11 +30,6 @@ async function checkProfile(context: HookContext) {
   if (profile === USER_PROFILE.MEMBER)
     throw new Forbidden("You don't have sufficient privilege to create a group.")
 }
-import { defineRules } from './group.ability'
-import { authorize } from 'feathers-casl'
-import { Forbidden } from '@feathersjs/errors'
-
-const authorizeHook = authorize({ adapter: '@feathersjs/knex' })
 
 export const groupHooks: HookMap<Application, GroupService> = {
   around: {
@@ -39,7 +40,7 @@ export const groupHooks: HookMap<Application, GroupService> = {
     ],
   },
   before: {
-    all: [defineRules, authorizeHook],
+    all: [setAbilities, authorizeHook],
     find: [
       schemaHooks.validateQuery(groupQueryValidator),
       schemaHooks.resolveQuery(groupResolvers.query),

--- a/api/src/services/core/group/group.class.ts
+++ b/api/src/services/core/group/group.class.ts
@@ -17,7 +17,7 @@ import { groupResolvers } from './group.resolver'
 import { authenticate } from '@feathersjs/authentication'
 
 import { setAbilities } from './group.ability'
-import { authorize, authorize } from 'feathers-casl'
+import { authorize } from 'feathers-casl'
 
 const authorizeHook = authorize({ adapter: '@feathersjs/knex' })
 

--- a/api/src/services/core/group/group.class.ts
+++ b/api/src/services/core/group/group.class.ts
@@ -16,7 +16,8 @@ import {
 } from './group.schema'
 import { groupResolvers } from './group.resolver'
 import { authenticate } from '@feathersjs/authentication'
-import { UserResult } from '@/services/core/user/user.schema'
+import { checkInternalCallOrSpecificProfile } from '@/hooks/profile.hooks'
+import { UserResult } from '../user/user.schema'
 
 async function checkProfile(context: HookContext) {
   const user: UserResult = context.params.user
@@ -35,6 +36,7 @@ export const groupHooks: HookMap<Application, GroupService> = {
     ],
   },
   before: {
+    all: [checkInternalCallOrSpecificProfile([USER_PROFILE.ADMIN])],
     find: [
       schemaHooks.validateQuery(groupQueryValidator),
       schemaHooks.resolveQuery(groupResolvers.query),

--- a/api/src/services/core/group/group.class.ts
+++ b/api/src/services/core/group/group.class.ts
@@ -3,7 +3,6 @@ import { HookContext, HookMap } from '@feathersjs/feathers'
 import { ObjectionService } from '@/feathers-objection'
 import { hooks as schemaHooks } from '@feathersjs/schema'
 import { Application } from '@/declarations'
-import { USER_PROFILE } from '@locokit/definitions'
 
 import {
   GroupData,

--- a/api/src/services/core/group/group.class.ts
+++ b/api/src/services/core/group/group.class.ts
@@ -1,5 +1,5 @@
 import { KnexAdapterParams } from '@feathersjs/knex'
-import { HookContext, HookMap } from '@feathersjs/feathers'
+import { HookMap } from '@feathersjs/feathers'
 import { ObjectionService } from '@/feathers-objection'
 import { hooks as schemaHooks } from '@feathersjs/schema'
 import { Application } from '@/declarations'
@@ -15,21 +15,11 @@ import {
 } from './group.schema'
 import { groupResolvers } from './group.resolver'
 import { authenticate } from '@feathersjs/authentication'
-import { UserResult } from '../user/user.schema'
 
 import { setAbilities } from './group.ability'
-import { authorize } from 'feathers-casl'
-import { Forbidden } from '@feathersjs/errors'
-import { USER_PROFILE } from '@locokit/definitions'
+import { authorize, authorize } from 'feathers-casl'
 
 const authorizeHook = authorize({ adapter: '@feathersjs/knex' })
-async function checkProfile(context: HookContext) {
-  const user: UserResult = context.params.user
-  const profile = user.profile
-
-  if (profile === USER_PROFILE.MEMBER)
-    throw new Forbidden("You don't have sufficient privilege to create a group.")
-}
 
 export const groupHooks: HookMap<Application, GroupService> = {
   around: {
@@ -46,17 +36,14 @@ export const groupHooks: HookMap<Application, GroupService> = {
       schemaHooks.resolveQuery(groupResolvers.query),
     ],
     create: [
-      checkProfile,
       schemaHooks.validateData(groupDataValidator),
       schemaHooks.resolveData(groupResolvers.data.create),
     ],
     patch: [
-      checkProfile,
       schemaHooks.validateData(groupPatchValidator),
       schemaHooks.resolveData(...groupResolvers.data.patch),
     ],
     update: [
-      checkProfile,
       schemaHooks.validateData(groupUpdateValidator),
       schemaHooks.resolveData(...groupResolvers.data.update),
     ],

--- a/api/src/services/core/group/group.resolver.ts
+++ b/api/src/services/core/group/group.resolver.ts
@@ -1,7 +1,7 @@
 import { resolve, Resolver } from '@feathersjs/schema'
 import type { HookContext } from '@/declarations'
 import { workspaceDispatchResolver } from '@/services/core/workspace/workspace.resolver'
-import { userDispatchResolver } from '@/services/core/user/user.resolver'
+import { userRestrictedDispatchResolver } from '@/services/core/user/user.resolver'
 import { GroupQuery, GroupSchema } from './group.schema'
 import { policyDispatchResolver } from '../policy/policy.resolver'
 
@@ -29,7 +29,7 @@ export const groupDefaultResolver: Resolver<GroupSchema, HookContext> = resolve<
   async users(users, _data, context) {
     if (users)
       return await Promise.all(
-        users.map(async (u) => await userDispatchResolver.resolve(u, context)),
+        users.map(async (u) => await userRestrictedDispatchResolver.resolve(u, context)),
       )
   },
 })

--- a/api/src/services/core/group/group.schema.ts
+++ b/api/src/services/core/group/group.schema.ts
@@ -4,6 +4,7 @@ import { dataValidator, queryValidator } from '@/commons/validators'
 import { workspaceOwnerSchema } from '@/services/core/user/user.schema'
 import { policySchema } from '../policy/policy.schema'
 import { queryStringExtend } from '@/feathers-objection'
+import { userGroupSchema } from '../user-group/user-group.schema'
 
 // Schema for the basic data model (e.g. creating new entries)
 export const groupSchema = Type.Object(
@@ -66,6 +67,16 @@ export const groupSchema = Type.Object(
         ),
       ),
     ),
+    usergroups: Type.Optional(
+      Type.Array(
+        Type.Object(
+          { ...userGroupSchema.properties },
+          {
+            description: 'Related user groups',
+          },
+        ),
+      ),
+    ),
     // policy: Type.Ref(),
   },
   {
@@ -84,9 +95,12 @@ export const groupDataSchema = Type.Omit(
 )
 export type GroupData = Static<typeof groupSchema>
 
-export const groupPatchSchema = Type.Partial(
-  Type.Omit(groupDataSchema, ['workspaceId'], { $id: 'GroupPatch' }),
-)
+export const groupUpdateSchema = Type.Omit(groupDataSchema, ['workspaceId'], {
+  $id: 'GroupUpdate',
+})
+export type GroupUpdate = Static<typeof groupUpdateSchema>
+
+export const groupPatchSchema = Type.Partial(groupUpdateSchema, { $id: 'GroupPatch' })
 export type GroupPatch = Static<typeof groupPatchSchema>
 
 export type GroupResult = Static<typeof groupSchema>
@@ -150,7 +164,7 @@ export const groupQuerySchema = Type.Intersect(
 export type GroupQuery = Static<typeof groupQuerySchema>
 
 export const groupDataValidator = getValidator(groupDataSchema, dataValidator)
-
+export const groupUpdateValidator = getValidator(groupUpdateSchema, dataValidator)
 export const groupPatchValidator = getValidator(groupPatchSchema, dataValidator)
 
 export const groupQueryValidator = getValidator(groupQuerySchema, queryValidator)

--- a/api/src/services/core/group/group.test.ts
+++ b/api/src/services/core/group/group.test.ts
@@ -1,25 +1,320 @@
 import { SERVICES } from '@locokit/definitions'
-import { describe, it, assert } from 'vitest'
+import { describe, it, assert, beforeAll, expect, afterAll } from 'vitest'
 import { createApp } from '../../../app'
+import { builderTestEnvironment, SetupData } from '@/configure.test'
 
 describe('[core] group service', () => {
   const app = createApp()
+  const builder = builderTestEnvironment('core-group')
+  let setupData: SetupData
+  const port = app.get('port') || 8998
+  // const getUrl = (pathname: string) =>
+  //   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  //   new URL(`http://${app.get('host') || 'localhost'}:${port}${pathname}`).toString()
+
+  beforeAll(async () => {
+    setupData = await builder.setupWorkspace()
+    await app.listen(port)
+  })
+
   it('registered the service', () => {
     const service = app.service(SERVICES.CORE_GROUP)
 
     assert.ok(service, 'Registered the service')
   })
 
-  it.todo('returns all group users when queried with $joinRelated users')
+  describe('external calls', () => {
+    describe('for ADMIN users', () => {
+      it('returns all groups paginated when user profile is ADMIN', async () => {
+        expect.assertions(2)
+        const result = await app.service(SERVICES.CORE_GROUP).find({
+          provider: 'external',
+          authenticated: true,
+          authentication: setupData.userAdminAuthentication,
+          user: setupData.userAdmin,
+        })
+        expect(result).toBeDefined()
+        expect(result.total).toBe(5)
+      })
 
-  it.todo('creates a new group if user is ADMIN')
+      it('returns all group users when queried with $joinRelated users, and some private properties', async () => {
+        expect.assertions(9)
+        const result = await app.service(SERVICES.CORE_GROUP).get(setupData.group1.id, {
+          provider: 'external',
+          authenticated: true,
+          authentication: setupData.userAdminAuthentication,
+          user: setupData.userAdmin,
+          query: {
+            $joinEager: 'users',
+          },
+        })
+        expect(result).toBeDefined()
+        expect(result.users).toBeDefined()
+        expect(result.users?.length).toBe(2)
+        // ADMIN users can access to email / blocked / isVerified
+        expect(result.users?.[0].email).toBeDefined()
+        expect(result.users?.[0].blocked).toBeDefined()
+        expect(result.users?.[0].isVerified).toBeDefined()
+        expect(result.users?.[1].email).toBeDefined()
+        expect(result.users?.[1].blocked).toBeDefined()
+        expect(result.users?.[1].isVerified).toBeDefined()
+      })
 
-  it.todo('creates a new group in a workspace if the user is CREATOR')
+      it('create a new group if user is ADMIN', async () => {
+        expect.assertions(1)
+        const result = await app.service(SERVICES.CORE_GROUP).create(
+          {
+            name: 'new group for ADMIN user',
+            workspaceId: setupData.workspace2Id,
+            policyId: setupData.policy1.id,
+          },
+          {
+            provider: 'external',
+            authenticated: true,
+            authentication: setupData.userAdminAuthentication,
+            user: setupData.userAdmin,
+          },
+        )
+        expect(result).toBeDefined()
+        await app.service(SERVICES.CORE_GROUP).remove(result.id)
+      })
+    })
 
-  it.todo('remove all sensitive data of users when retrieving users relation')
+    describe('for other users', () => {
+      it('returns only user groups when user profile is not ADMIN', async () => {
+        expect.assertions(3)
+        const result = await app.service(SERVICES.CORE_GROUP).find({
+          provider: 'external',
+          authenticated: true,
+          authentication: setupData.user4Authentication,
+          user: setupData.user4,
+          query: {
+            $sort: {
+              createdAt: 1, // sort by createdAt to match ids in creation time
+            },
+          },
+        })
+        expect(result).toBeDefined()
+        expect(result.total).toBe(1)
+        expect(result.data[0].id).toBe(setupData.group4.id)
+      })
+      it('returns user groups and workspace groups when user profile is also a workspace owner', async () => {
+        expect.assertions(5)
+        const result = await app.service(SERVICES.CORE_GROUP).find({
+          provider: 'external',
+          authenticated: true,
+          authentication: setupData.user1Authentication,
+          user: setupData.user1,
+          query: {
+            $sort: {
+              createdAt: 1, // sort by createdAt to match ids in creation time
+            },
+          },
+        })
+        expect(result).toBeDefined()
+        expect(result.total).toBe(3)
+        expect(result.data[0].id).toBe(setupData.group1.id)
+        expect(result.data[1].id).toBe(setupData.group2.id)
+        expect(result.data[2].id).toBe(setupData.group5.id)
+      })
 
-  it.todo('filter on workspace name')
-  it.todo('filter on workspace owner username')
+      it('returns all group users when queried with $joinRelated users without sensitive data', async () => {
+        expect.assertions(9)
+        const result = await app.service(SERVICES.CORE_GROUP).get(setupData.group1.id, {
+          provider: 'external',
+          authenticated: true,
+          authentication: setupData.user1Authentication,
+          user: setupData.user1,
+          query: {
+            $joinEager: 'users',
+          },
+        })
+        expect(result).toBeDefined()
+        expect(result.users).toBeDefined()
+        expect(result.users?.length).toBe(2)
+        // ADMIN users can access to email / blocked / isVerified
+        expect(result.users?.[0].email).not.toBeDefined()
+        expect(result.users?.[0].blocked).not.toBeDefined()
+        expect(result.users?.[0].isVerified).not.toBeDefined()
+        expect(result.users?.[1].email).not.toBeDefined()
+        expect(result.users?.[1].blocked).not.toBeDefined()
+        expect(result.users?.[1].isVerified).not.toBeDefined()
+      })
+      it('create a new group in a workspace if the user is its CREATOR', async () => {
+        expect.assertions(1)
+        const result = await app.service(SERVICES.CORE_GROUP).create(
+          {
+            name: 'new group for CREATOR user',
+            workspaceId: setupData.workspace2Id,
+            policyId: setupData.policy1.id,
+          },
+          {
+            provider: 'external',
+            authenticated: true,
+            authentication: setupData.user2Authentication,
+            user: setupData.user2,
+          },
+        )
+        expect(result).toBeDefined()
+        await app.service(SERVICES.CORE_GROUP).remove(result.id)
+      })
+      it('forbid to create a new group in a workspace if the user is not the owner', async () => {
+        expect.assertions(2)
+        const request = app.service(SERVICES.CORE_GROUP).create(
+          {
+            name: 'new group for CREATOR user',
+            workspaceId: setupData.workspace2Id,
+            policyId: setupData.policy1.id,
+          },
+          {
+            provider: 'external',
+            authenticated: true,
+            authentication: setupData.user4Authentication,
+            user: setupData.user4,
+          },
+        )
+        await expect(request).rejects.toThrow()
+        await expect(request).rejects.toThrowError(/You are not allowed to create core\/group/)
+      })
+      it('forbid group creation for MEMBER', async () => {
+        expect.assertions(2)
+        const request = app.service(SERVICES.CORE_GROUP).create(
+          {
+            name: 'new group for CREATOR user',
+            workspaceId: setupData.workspace2Id,
+            policyId: setupData.policy1.id,
+          },
+          {
+            provider: 'external',
+            authenticated: true,
+            authentication: setupData.user3Authentication,
+            user: setupData.user3,
+          },
+        )
+        await expect(request).rejects.toThrow()
+        await expect(request).rejects.toThrowError(/You are not allowed to create core\/group/)
+      })
+      it('forbid group patch for MEMBER', async () => {
+        expect.assertions(2)
+        const request = app.service(SERVICES.CORE_GROUP).patch(
+          setupData.group1.id,
+          {},
+          {
+            provider: 'external',
+            authenticated: true,
+            authentication: setupData.user3Authentication,
+            user: setupData.user3,
+          },
+        )
+        await expect(request).rejects.toThrow()
+        await expect(request).rejects.toThrowError(/You are not allowed to patch core\/group/)
+      })
+      it('forbid group removal for MEMBER', async () => {
+        expect.assertions(2)
+        const request = app.service(SERVICES.CORE_GROUP).remove(setupData.group1.id, {
+          provider: 'external',
+          authenticated: true,
+          authentication: setupData.user3Authentication,
+          user: setupData.user3,
+        })
+        await expect(request).rejects.toThrow()
+        await expect(request).rejects.toThrowError(/You are not allowed to remove core\/group/)
+      })
+    })
+  })
 
-  it.todo('filter on workspace name AND group name ($joinEager with objection + validation)')
+  describe('filter', () => {
+    it('filter on group name', async () => {
+      expect.assertions(2)
+      const result = await app.service(SERVICES.CORE_GROUP).find({
+        query: {
+          name: {
+            $ilike: '%core-group%',
+          },
+        },
+      })
+      expect(result).toBeDefined()
+      expect(result.total).toBe(5)
+    })
+    it('filter on workspace name', async () => {
+      expect.assertions(2)
+      const result = await app.service(SERVICES.CORE_GROUP).find({
+        query: {
+          $joinRelated: 'workspace',
+          'workspace.name': {
+            $ilike: '%Public workspace%',
+          },
+        },
+      })
+      expect(result).toBeDefined()
+      expect(result.total).toBe(3)
+    })
+    it('filter on workspace owner username', async () => {
+      expect.assertions(2)
+      const result = await app.service(SERVICES.CORE_GROUP).find({
+        query: {
+          $joinRelated: 'workspace.owner',
+          'workspace:owner.username': {
+            $ilike: '%user2%',
+          },
+        },
+      })
+      expect(result).toBeDefined()
+      expect(result.total).toBe(2)
+    })
+
+    it('filter on workspace name AND group name ($joinEager with objection + validation)', async () => {
+      expect.assertions(2)
+      const result = await app.service(SERVICES.CORE_GROUP).find({
+        query: {
+          $joinRelated: 'workspace',
+          'workspace.name': {
+            $ilike: '%Workspace 2%',
+          },
+          name: {
+            $ilike: '%core-group%',
+          },
+        },
+      })
+      expect(result).toBeDefined()
+      expect(result.total).toBe(2)
+    })
+  })
+  describe('internal calls are not restricted', () => {
+    it('for read', async () => {
+      expect.assertions(2)
+      const result = await app.service(SERVICES.CORE_GROUP).find({})
+      expect(result).toBeDefined()
+      expect(result.total).toBe(5)
+    })
+    it('for creation', async () => {
+      expect.assertions(1)
+      const result = await app.service(SERVICES.CORE_GROUP).create({
+        name: 'new group for ADMIN user',
+        workspaceId: setupData.workspace2Id,
+        policyId: setupData.policy1.id,
+      })
+      expect(result).toBeDefined()
+      await app.service(SERVICES.CORE_GROUP).remove(result.id)
+    })
+    it('for patch', async () => {
+      expect.assertions(2)
+      const result = await app.service(SERVICES.CORE_GROUP).create({
+        name: 'new group for ADMIN user',
+        workspaceId: setupData.workspace2Id,
+        policyId: setupData.policy1.id,
+      })
+      expect(result).toBeDefined()
+      const resultPatched = await app.service(SERVICES.CORE_GROUP).patch(result.id, {
+        name: 'new name',
+      })
+      expect(resultPatched.name).toBe('new name')
+      await app.service(SERVICES.CORE_GROUP).remove(result.id)
+    })
+    // for removal, already removed...
+  })
+
+  afterAll(async () => {
+    await builder.teardownWorkspace()
+  })
 })

--- a/api/src/services/core/group/group.test.ts
+++ b/api/src/services/core/group/group.test.ts
@@ -65,7 +65,7 @@ describe('[core] group service', () => {
         const result = await app.service(SERVICES.CORE_GROUP).create(
           {
             name: 'new group for ADMIN user',
-            workspaceId: setupData.workspace2Id,
+            workspaceId: setupData.privateWorkspaceId,
             policyId: setupData.policy1.id,
           },
           {
@@ -86,8 +86,8 @@ describe('[core] group service', () => {
         const result = await app.service(SERVICES.CORE_GROUP).find({
           provider: 'external',
           authenticated: true,
-          authentication: setupData.user4Authentication,
-          user: setupData.user4,
+          authentication: setupData.userCreator4Authentication,
+          user: setupData.userCreator4,
           query: {
             $sort: {
               createdAt: 1, // sort by createdAt to match ids in creation time
@@ -103,8 +103,8 @@ describe('[core] group service', () => {
         const result = await app.service(SERVICES.CORE_GROUP).find({
           provider: 'external',
           authenticated: true,
-          authentication: setupData.user1Authentication,
-          user: setupData.user1,
+          authentication: setupData.userCreator1Authentication,
+          user: setupData.userCreator1,
           query: {
             $sort: {
               createdAt: 1, // sort by createdAt to match ids in creation time
@@ -123,8 +123,8 @@ describe('[core] group service', () => {
         const result = await app.service(SERVICES.CORE_GROUP).get(setupData.group1.id, {
           provider: 'external',
           authenticated: true,
-          authentication: setupData.user1Authentication,
-          user: setupData.user1,
+          authentication: setupData.userCreator1Authentication,
+          user: setupData.userCreator1,
           query: {
             $joinEager: 'users',
           },
@@ -145,7 +145,7 @@ describe('[core] group service', () => {
         const result = await app.service(SERVICES.CORE_GROUP).create(
           {
             name: 'new group for CREATOR user',
-            workspaceId: setupData.workspace2Id,
+            workspaceId: setupData.privateWorkspaceId,
             policyId: setupData.policy1.id,
           },
           {
@@ -163,14 +163,14 @@ describe('[core] group service', () => {
         const request = app.service(SERVICES.CORE_GROUP).create(
           {
             name: 'new group for CREATOR user',
-            workspaceId: setupData.workspace2Id,
+            workspaceId: setupData.privateWorkspaceId,
             policyId: setupData.policy1.id,
           },
           {
             provider: 'external',
             authenticated: true,
-            authentication: setupData.user4Authentication,
-            user: setupData.user4,
+            authentication: setupData.userCreator4Authentication,
+            user: setupData.userCreator4,
           },
         )
         await expect(request).rejects.toThrow()
@@ -181,7 +181,7 @@ describe('[core] group service', () => {
         const request = app.service(SERVICES.CORE_GROUP).create(
           {
             name: 'new group for CREATOR user',
-            workspaceId: setupData.workspace2Id,
+            workspaceId: setupData.privateWorkspaceId,
             policyId: setupData.policy1.id,
           },
           {
@@ -291,7 +291,7 @@ describe('[core] group service', () => {
       expect.assertions(1)
       const result = await app.service(SERVICES.CORE_GROUP).create({
         name: 'new group for ADMIN user',
-        workspaceId: setupData.workspace2Id,
+        workspaceId: setupData.privateWorkspaceId,
         policyId: setupData.policy1.id,
       })
       expect(result).toBeDefined()
@@ -301,7 +301,7 @@ describe('[core] group service', () => {
       expect.assertions(2)
       const result = await app.service(SERVICES.CORE_GROUP).create({
         name: 'new group for ADMIN user',
-        workspaceId: setupData.workspace2Id,
+        workspaceId: setupData.privateWorkspaceId,
         policyId: setupData.policy1.id,
       })
       expect(result).toBeDefined()

--- a/api/src/services/core/policy/policy.class.ts
+++ b/api/src/services/core/policy/policy.class.ts
@@ -21,7 +21,7 @@ export const policyHooks: HookMap<Application, PolicyService> = {
   before: {
     all: [
       checkUserHasAccess({
-        userProfile: [USER_PROFILE.ADMIN],
+        allowedProfile: [USER_PROFILE.ADMIN],
         internalProvider: true,
         internalProviderProfileCheck: 'IF_USER_PROVIDED',
       }),

--- a/api/src/services/core/policy/policy.class.ts
+++ b/api/src/services/core/policy/policy.class.ts
@@ -8,7 +8,7 @@ import { authenticate } from '@feathersjs/authentication'
 import { ObjectionService } from '@/feathers-objection'
 import { USER_PROFILE } from '@locokit/definitions'
 import { HookMap } from '@feathersjs/feathers'
-import { checkInternalCallOrSpecificProfile } from '@/hooks/profile.hooks'
+import { checkUserHasAccess } from '@/hooks/profile.hooks'
 
 export const policyHooks: HookMap<Application, PolicyService> = {
   around: {
@@ -19,7 +19,13 @@ export const policyHooks: HookMap<Application, PolicyService> = {
     ],
   },
   before: {
-    all: [checkInternalCallOrSpecificProfile([USER_PROFILE.ADMIN])],
+    all: [
+      checkUserHasAccess({
+        userProfile: [USER_PROFILE.ADMIN],
+        internalProvider: true,
+        internalProviderProfileCheck: 'IF_USER_PROVIDED',
+      }),
+    ],
     find: [
       schemaHooks.validateQuery(policyQueryValidator),
       schemaHooks.resolveQuery(policyResolvers.query),

--- a/api/src/services/core/policy/policy.class.ts
+++ b/api/src/services/core/policy/policy.class.ts
@@ -3,13 +3,12 @@ import { hooks as schemaHooks } from '@feathersjs/schema'
 
 import { PolicyData, PolicyResult, PolicyQuery, policyDataValidator } from './policy.schema'
 import { policyQueryValidator, policyResolvers } from './policy.resolver'
-import { Application, HookContext } from '@/declarations'
+import { Application } from '@/declarations'
 import { authenticate } from '@feathersjs/authentication'
 import { ObjectionService } from '@/feathers-objection'
-import { UserResult } from '@/services/core/user/user.schema'
 import { USER_PROFILE } from '@locokit/definitions'
-import { Forbidden } from '@feathersjs/errors/lib'
 import { HookMap } from '@feathersjs/feathers'
+import { checkInternalCallOrSpecificProfile } from '@/hooks/profile.hooks'
 
 export const policyHooks: HookMap<Application, PolicyService> = {
   around: {
@@ -20,6 +19,7 @@ export const policyHooks: HookMap<Application, PolicyService> = {
     ],
   },
   before: {
+    all: [checkInternalCallOrSpecificProfile([USER_PROFILE.ADMIN])],
     find: [
       schemaHooks.validateQuery(policyQueryValidator),
       schemaHooks.resolveQuery(policyResolvers.query),
@@ -27,13 +27,6 @@ export const policyHooks: HookMap<Application, PolicyService> = {
     create: [
       schemaHooks.validateData(policyDataValidator),
       schemaHooks.resolveData(policyResolvers.data.create),
-      async function checkProfile(context: HookContext) {
-        const user: UserResult = context.params.user
-        const profile = user.profile
-
-        if (profile === USER_PROFILE.MEMBER)
-          throw new Forbidden("You don't have sufficient privilege to create a policy.")
-      },
     ],
   },
   after: {

--- a/api/src/services/core/policy/policy.schema.ts
+++ b/api/src/services/core/policy/policy.schema.ts
@@ -42,7 +42,7 @@ export type PolicySchema = Static<typeof policySchema>
 export const policyDataSchema = Type.Omit(policySchema, ['id', 'workspace'], {
   $id: 'PolicyData',
 })
-export type PolicyData = Static<typeof policySchema>
+export type PolicyData = Static<typeof policyDataSchema>
 
 export const policyPatchSchema = Type.Partial(Type.Omit(policyDataSchema, ['workspaceId']), {
   $id: 'PolicyPatch',

--- a/api/src/services/core/table/table.hooks.ts
+++ b/api/src/services/core/table/table.hooks.ts
@@ -1,31 +1,15 @@
 import { authenticate } from '@feathersjs/authentication'
 import { transaction } from '@/feathers-objection'
-import { HookContext } from '@/declarations'
-import { USER_PROFILE } from '@locokit/definitions'
-import { Forbidden } from '@feathersjs/errors/lib'
 import { hooks as schemaHooks } from '@feathersjs/schema'
 import { coreTablePatchResolver } from './table.resolver'
+import { isInternalCallOrAdminProfile } from '@/hooks/profile.hooks'
 
 export const coreTableHooks = {
   around: {
     all: [authenticate('jwt')],
   },
   before: {
-    all: [
-      async function checkProfile(context: HookContext) {
-        /**
-         * Let the user pass if it's an internal call
-         */
-        if (!context.params.provider) return context
-
-        /**
-         * Check the user is an admin one
-         */
-        if (context.params.user.profile !== USER_PROFILE.ADMIN)
-          throw new Forbidden("You can't access datasources.")
-      },
-      transaction.start(),
-    ],
+    all: [isInternalCallOrAdminProfile, transaction.start()],
     patch: [schemaHooks.resolveData(coreTablePatchResolver)],
   },
   after: {

--- a/api/src/services/core/table/table.hooks.ts
+++ b/api/src/services/core/table/table.hooks.ts
@@ -2,14 +2,14 @@ import { authenticate } from '@feathersjs/authentication'
 import { transaction } from '@/feathers-objection'
 import { hooks as schemaHooks } from '@feathersjs/schema'
 import { coreTablePatchResolver } from './table.resolver'
-import { isInternalCallOrAdminProfile } from '@/hooks/profile.hooks'
+import { isInternalCallOrInternalAndAdminProfile } from '@/hooks/profile.hooks'
 
 export const coreTableHooks = {
   around: {
     all: [authenticate('jwt')],
   },
   before: {
-    all: [isInternalCallOrAdminProfile, transaction.start()],
+    all: [isInternalCallOrInternalAndAdminProfile, transaction.start()],
     patch: [schemaHooks.resolveData(coreTablePatchResolver)],
   },
   after: {

--- a/api/src/services/core/table/table.hooks.ts
+++ b/api/src/services/core/table/table.hooks.ts
@@ -14,7 +14,7 @@ export const coreTableHooks = {
       checkUserHasAccess({
         allowedProfile: [USER_PROFILE.ADMIN],
         internalProvider: true,
-        internalProviderProfileCheck: 'ALWAYS',
+        internalProviderProfileCheck: 'IF_USER_PROVIDED',
       }),
       transaction.start(),
     ],

--- a/api/src/services/core/table/table.hooks.ts
+++ b/api/src/services/core/table/table.hooks.ts
@@ -2,14 +2,22 @@ import { authenticate } from '@feathersjs/authentication'
 import { transaction } from '@/feathers-objection'
 import { hooks as schemaHooks } from '@feathersjs/schema'
 import { coreTablePatchResolver } from './table.resolver'
-import { isInternalCallOrInternalAndAdminProfile } from '@/hooks/profile.hooks'
+import { checkUserHasAccess } from '@/hooks/profile.hooks'
+import { USER_PROFILE } from '@locokit/definitions'
 
 export const coreTableHooks = {
   around: {
     all: [authenticate('jwt')],
   },
   before: {
-    all: [isInternalCallOrInternalAndAdminProfile, transaction.start()],
+    all: [
+      checkUserHasAccess({
+        userProfile: [USER_PROFILE.ADMIN],
+        internalProvider: true,
+        internalProviderProfileCheck: 'ALWAYS',
+      }),
+      transaction.start(),
+    ],
     patch: [schemaHooks.resolveData(coreTablePatchResolver)],
   },
   after: {

--- a/api/src/services/core/table/table.hooks.ts
+++ b/api/src/services/core/table/table.hooks.ts
@@ -12,7 +12,7 @@ export const coreTableHooks = {
   before: {
     all: [
       checkUserHasAccess({
-        userProfile: [USER_PROFILE.ADMIN],
+        allowedProfile: [USER_PROFILE.ADMIN],
         internalProvider: true,
         internalProviderProfileCheck: 'ALWAYS',
       }),

--- a/api/src/services/core/user-group/user-group.class.ts
+++ b/api/src/services/core/user-group/user-group.class.ts
@@ -26,7 +26,7 @@ export const userGroupHooks: HookMap<Application, UserGroupService> = {
   before: {
     all: [
       checkUserHasAccess({
-        userProfile: [USER_PROFILE.ADMIN, USER_PROFILE.CREATOR],
+        allowedProfile: [USER_PROFILE.ADMIN, USER_PROFILE.CREATOR],
         internalProvider: true,
         internalProviderProfileCheck: 'IF_USER_PROVIDED',
       }),

--- a/api/src/services/core/user-group/user-group.class.ts
+++ b/api/src/services/core/user-group/user-group.class.ts
@@ -8,13 +8,12 @@ import {
   userGroupDataValidator,
 } from './user-group.schema'
 import { userGroupQueryValidator, userGroupResolvers } from './user-group.resolver'
-import { Application, HookContext } from '@/declarations'
+import { Application } from '@/declarations'
 import { authenticate } from '@feathersjs/authentication'
 import { ObjectionService } from '@/feathers-objection'
-import { UserResult } from '../../core/user/user.schema'
 import { USER_PROFILE } from '@locokit/definitions'
-import { Forbidden } from '@feathersjs/errors/lib'
 import { HookMap } from '@feathersjs/feathers'
+import { checkInternalCallOrSpecificProfile } from '@/hooks/profile.hooks'
 
 export const userGroupHooks: HookMap<Application, UserGroupService> = {
   around: {
@@ -25,6 +24,7 @@ export const userGroupHooks: HookMap<Application, UserGroupService> = {
     ],
   },
   before: {
+    all: [checkInternalCallOrSpecificProfile([USER_PROFILE.ADMIN, USER_PROFILE.CREATOR])],
     find: [
       schemaHooks.validateQuery(userGroupQueryValidator),
       schemaHooks.resolveQuery(userGroupResolvers.query),
@@ -32,13 +32,6 @@ export const userGroupHooks: HookMap<Application, UserGroupService> = {
     create: [
       schemaHooks.resolveData(userGroupResolvers.data.create),
       schemaHooks.validateData(userGroupDataValidator),
-      async function checkProfile(context: HookContext) {
-        const user: UserResult = context.params.user
-        const profile = user.profile
-
-        if (profile === USER_PROFILE.MEMBER)
-          throw new Forbidden("You don't have sufficient privilege to create a group.")
-      },
     ],
   },
   after: {},

--- a/api/src/services/core/user-group/user-group.class.ts
+++ b/api/src/services/core/user-group/user-group.class.ts
@@ -13,7 +13,7 @@ import { authenticate } from '@feathersjs/authentication'
 import { ObjectionService } from '@/feathers-objection'
 import { USER_PROFILE } from '@locokit/definitions'
 import { HookMap } from '@feathersjs/feathers'
-import { checkInternalCallOrSpecificProfile } from '@/hooks/profile.hooks'
+import { checkUserHasAccess } from '@/hooks/profile.hooks'
 
 export const userGroupHooks: HookMap<Application, UserGroupService> = {
   around: {
@@ -24,7 +24,13 @@ export const userGroupHooks: HookMap<Application, UserGroupService> = {
     ],
   },
   before: {
-    all: [checkInternalCallOrSpecificProfile([USER_PROFILE.ADMIN, USER_PROFILE.CREATOR])],
+    all: [
+      checkUserHasAccess({
+        userProfile: [USER_PROFILE.ADMIN, USER_PROFILE.CREATOR],
+        internalProvider: true,
+        internalProviderProfileCheck: 'IF_USER_PROVIDED',
+      }),
+    ],
     find: [
       schemaHooks.validateQuery(userGroupQueryValidator),
       schemaHooks.resolveQuery(userGroupResolvers.query),

--- a/api/src/services/core/user-group/user-group.schema.ts
+++ b/api/src/services/core/user-group/user-group.schema.ts
@@ -31,10 +31,10 @@ dataValidator.addSchema(userGroupSchema)
 
 export type UserGroupSchema = Static<typeof userGroupSchema>
 
-export const userGroupDataSchema = Type.Omit(userGroupSchema, ['user', 'group'], {
-  $id: 'UsesrGroupData',
+export const userGroupDataSchema = Type.Pick(userGroupSchema, ['userId', 'groupId'], {
+  $id: 'UserGroupData',
 })
-export type UserGroupData = Static<typeof userGroupSchema>
+export type UserGroupData = Static<typeof userGroupDataSchema>
 
 export const userGroupPatchSchema = Type.Never()
 export type UserGroupPatch = Static<typeof userGroupPatchSchema>

--- a/api/src/services/core/user/user.hooks.ts
+++ b/api/src/services/core/user/user.hooks.ts
@@ -16,7 +16,7 @@ import {
 } from './user.resolver'
 import { disallow, iff, isProvider } from 'feathers-hooks-common'
 import { addVerification } from 'feathers-authentication-management'
-import { isAdminProfile } from '@/hooks/profile.hooks'
+import { checkUserIsAdmin } from '@/hooks/profile.hooks'
 import { HookOptions } from '@feathersjs/feathers'
 import type { Application, HookContext } from '@/declarations'
 import { UserService } from './user.class'
@@ -43,7 +43,7 @@ export const hooks: HookOptions<Application, UserService> = {
     get: [
       iff(
         (context: HookContext) => {
-          return isProvider('external')(context) && !isAdminProfile(context)
+          return isProvider('external')(context) && !checkUserIsAdmin(context)
         },
         validateQuery(userQueryValidator),
         resolveQuery(userQueryResolver),
@@ -55,7 +55,7 @@ export const hooks: HookOptions<Application, UserService> = {
       // otherwise, could search on "username"
       // need to return only "username" for non admin users
       iff((context: HookContext) => {
-        return isProvider('external')(context) && !isAdminProfile(context)
+        return isProvider('external')(context) && !checkUserIsAdmin(context)
       }, validateQuery(userQueryValidator)),
     ],
     create: [
@@ -64,7 +64,7 @@ export const hooks: HookOptions<Application, UserService> = {
        * from external calls and user not admin
        */
       iff((context: HookContext) => {
-        return isProvider('external')(context) && !isAdminProfile(context)
+        return isProvider('external')(context) && !checkUserIsAdmin(context)
       }, disallow()).else(
         validateData(userDataValidator),
         addVerification(SERVICES.AUTH_MANAGEMENT),
@@ -84,7 +84,7 @@ export const hooks: HookOptions<Application, UserService> = {
       iff(
         isProvider('external'),
         iff(
-          isAdminProfile,
+          checkUserIsAdmin,
           validateData(userPatchAdminValidator),
           resolveData(userPatchAdminResolver),
         ).else(validateData(userPatchValidator), resolveData(userPatchResolver)),
@@ -95,7 +95,7 @@ export const hooks: HookOptions<Application, UserService> = {
       /**
        * User not admin can't remove user
        */
-      iff(!isAdminProfile, disallow()),
+      iff(!checkUserIsAdmin, disallow()),
     ],
   },
   after: {

--- a/api/src/services/core/user/user.test.ts
+++ b/api/src/services/core/user/user.test.ts
@@ -18,8 +18,8 @@ describe('[core] user service', () => {
   })
 
   afterAll(async () => {
-    await app.teardown()
     await builder.teardownWorkspace()
+    await app.teardown()
   })
 
   it('registered the service', () => {

--- a/api/src/services/core/user/user.test.ts
+++ b/api/src/services/core/user/user.test.ts
@@ -58,7 +58,7 @@ describe('[core] user service', () => {
       expect(res.data).toHaveProperty('isVerified')
       expect(res.data).toHaveProperty('createdAt')
       expect(res.data).not.toHaveProperty('password')
-      expect(res.data.username).toBe('User 2')
+      expect(res.data.username).toBe('authentication-user2')
     })
 
     it('User try to get other user information', async () => {

--- a/api/src/services/core/workspace/workspace.test.ts
+++ b/api/src/services/core/workspace/workspace.test.ts
@@ -34,7 +34,7 @@ describe('[core] workspace service', () => {
         name: 'core-workspace public',
         documentation: 'Public workspace',
         public: true,
-        createdBy: setupData.user1.id,
+        createdBy: setupData.userCreator1.id,
       })
 
       expect(workspace).toBeDefined()
@@ -124,7 +124,7 @@ describe('[core] workspace service', () => {
         name: '[core-workspace] WS 1',
         documentation: 'Core workspace for testing creation of a dedicated SQL workspace',
         public: false,
-        createdBy: setupData.user1.id,
+        createdBy: setupData.userCreator1.id,
       })
       schemaName = 'w_' + ws.slug
     })
@@ -229,7 +229,7 @@ describe('[core] workspace service', () => {
         name: 'for removal purpose',
         documentation: 'Core workspace for testing forbid workspace removal for non admin users',
         public: false,
-        createdBy: setupData.user1.id,
+        createdBy: setupData.userCreator1.id,
       })
       alreadyRemoved = false
       schemaName = 'w_' + resWorkspace.slug
@@ -244,7 +244,7 @@ describe('[core] workspace service', () => {
        */
       await axios.delete(getUrl(SERVICES.CORE_WORKSPACE) + '/' + resWorkspace.id, {
         headers: {
-          Authorization: 'Bearer ' + (setupData.user1Authentication.accessToken as string),
+          Authorization: 'Bearer ' + (setupData.userCreator1Authentication.accessToken as string),
         },
       })
 
@@ -336,18 +336,18 @@ describe('[core] workspace service', () => {
 
       // first removal, we have a softDeletedAt
       const wsFirstRemoval = await app.service(SERVICES.CORE_WORKSPACE).remove(resWorkspace.id, {
-        user: setupData.user1,
+        user: setupData.userCreator1,
         authenticated: true,
-        authentication: setupData.user1Authentication,
+        authentication: setupData.userCreator1Authentication,
       })
       expect(wsFirstRemoval.softDeletedAt).not.toBeNull()
 
       // second removal, we have an error
       await expect(
         app.service(SERVICES.CORE_WORKSPACE).remove(resWorkspace.id, {
-          user: setupData.user1,
+          user: setupData.userCreator1,
           authenticated: true,
-          authentication: setupData.user1Authentication,
+          authentication: setupData.userCreator1Authentication,
         }),
       ).rejects.toThrowError(/Workspace is already soft-deleted./)
     })
@@ -365,8 +365,8 @@ describe('[core] workspace service', () => {
       // remove workspace as owner (so soft-deleted)
       await app.service(SERVICES.CORE_WORKSPACE).remove(resWorkspace.id, {
         authenticated: true,
-        user: setupData.user1,
-        authentication: setupData.user1Authentication,
+        user: setupData.userCreator1,
+        authentication: setupData.userCreator1Authentication,
       })
       // find again, expect one less
       const workspacesAfter = await app.service(SERVICES.CORE_WORKSPACE).find({
@@ -394,8 +394,8 @@ describe('[core] workspace service', () => {
       // remove workspace as owner (so soft-deleted)
       await app.service(SERVICES.CORE_WORKSPACE).remove(resWorkspace.id, {
         authenticated: true,
-        user: setupData.user1,
-        authentication: setupData.user1Authentication,
+        user: setupData.userCreator1,
+        authentication: setupData.userCreator1Authentication,
       })
       // find again, expect the same
       const workspacesAfter = await app.service(SERVICES.CORE_WORKSPACE).find({
@@ -449,8 +449,8 @@ describe('[core] workspace service', () => {
           },
           {
             authenticated: true,
-            user: setupData.user1,
-            authentication: setupData.user1Authentication,
+            user: setupData.userCreator1,
+            authentication: setupData.userCreator1Authentication,
           },
         ),
       ).rejects.toThrow(BadRequest)
@@ -512,7 +512,7 @@ describe('[core] workspace service', () => {
         name: 'private repo for filtering',
         documentation: 'Core workspace for testing filtering public workspace',
         public: false,
-        createdBy: setupData.user1.id,
+        createdBy: setupData.userCreator1.id,
       })
       privateWorkspace2 = await app.service(SERVICES.CORE_WORKSPACE).create({
         name: 'private repo 2 for filtering',
@@ -532,7 +532,7 @@ describe('[core] workspace service', () => {
       const resultFilter = await app.service(SERVICES.CORE_WORKSPACE).find({
         query: {
           $joinEager: 'owner',
-          'owner.username': setupData.user1.username,
+          'owner.username': setupData.userCreator1.username,
         },
         authenticated: false,
         authentication: {
@@ -552,7 +552,7 @@ describe('[core] workspace service', () => {
       const resultFilter = await app.service(SERVICES.CORE_WORKSPACE).find({
         query: {
           $joinRelated: 'owner',
-          'owner.username': setupData.user1.username,
+          'owner.username': setupData.userCreator1.username,
         },
         authenticated: false,
         authentication: {
@@ -605,19 +605,19 @@ describe('[core] workspace service', () => {
 
       const allWs = await app.service(SERVICES.CORE_WORKSPACE).find({
         authenticated: true,
-        user: setupData.user1,
-        authentication: setupData.user1Authentication,
+        user: setupData.userCreator1,
+        authentication: setupData.userCreator1Authentication,
       })
       expect(allWs.total).toBe(3)
 
       const result = await app.service(SERVICES.CORE_WORKSPACE).find({
         query: {
           $joinEager: 'owner',
-          'owner.username': setupData.user1.username,
+          'owner.username': setupData.userCreator1.username,
         },
         authenticated: true,
-        user: setupData.user1,
-        authentication: setupData.user1Authentication,
+        user: setupData.userCreator1,
+        authentication: setupData.userCreator1Authentication,
       })
       expect(result.total).toBe(2)
     })
@@ -635,8 +635,8 @@ describe('[core] workspace service', () => {
       // soft-delete the private workspace
       await app.service(SERVICES.CORE_WORKSPACE).remove(privateWorkspace.id, {
         authenticated: true,
-        user: setupData.user1,
-        authentication: setupData.user1Authentication,
+        user: setupData.userCreator1,
+        authentication: setupData.userCreator1Authentication,
       })
 
       // check public user see only 1 workspace now
@@ -763,7 +763,7 @@ $BODY$;
         name: 'for removal purpose',
         documentation: 'Core workspace for testing forbid workspace removal for non admin users',
         public: false,
-        createdBy: setupData.user1.id,
+        createdBy: setupData.userCreator1.id,
       })
       const workspaceSlug = 'w_' + (workspace.slug as string)
 
@@ -817,7 +817,7 @@ $BODY$;
         name: 'for removal purpose',
         documentation: 'Core workspace for testing forbid workspace removal for non admin users',
         public: false,
-        createdBy: setupData.user1.id,
+        createdBy: setupData.userCreator1.id,
       })
       const workspaceSlug = 'w_' + (workspace.slug as string)
       // setup / mock the core-workspace for overwrite the `_remove` function and fail
@@ -955,7 +955,7 @@ $BODY$;
         name: 'for removal purpose',
         documentation: 'Core workspace for testing forbid workspace removal for non admin users',
         public: false,
-        createdBy: setupData.user1.id,
+        createdBy: setupData.userCreator1.id,
       })
       // try to patch the name => fail
       await expect(

--- a/api/src/services/core/workspace/workspace.test.ts
+++ b/api/src/services/core/workspace/workspace.test.ts
@@ -51,13 +51,17 @@ describe('[core] workspace service', () => {
       })
     })
 
-    it('returns the public workspace when making a find request of internal calls', async () => {
+    it('returns all workspaces when making a find request from internal', async () => {
       expect.assertions(3)
-      const publicWorkspaces = await app.service(SERVICES.CORE_WORKSPACE).find()
+      const workspaces = await app.service(SERVICES.CORE_WORKSPACE).find()
 
-      expect(publicWorkspaces.total).toBe(1)
-      expect(publicWorkspaces.data[0]).toBeDefined()
-      expect(publicWorkspaces.data[0].name).toContain('Public workspace')
+      expect(workspaces.total).toBe(2)
+      expect(
+        [setupData.publicWorkspaceId, setupData.privateWorkspaceId].includes(workspaces.data[0].id),
+      ).toBe(true)
+      expect(
+        [setupData.publicWorkspaceId, setupData.privateWorkspaceId].includes(workspaces.data[1].id),
+      ).toBe(true)
     })
 
     it('returns the public workspace when making a find request for unauthenticated users', async () => {
@@ -360,7 +364,7 @@ describe('[core] workspace service', () => {
           $limit: 0,
         },
       })
-      expect(workspaces.total).toBe(2)
+      expect(workspaces.total).toBe(3)
 
       // remove workspace as owner (so soft-deleted)
       await app.service(SERVICES.CORE_WORKSPACE).remove(resWorkspace.id, {
@@ -374,7 +378,7 @@ describe('[core] workspace service', () => {
           $limit: 0,
         },
       })
-      expect(workspacesAfter.total).toBe(1)
+      expect(workspacesAfter.total).toBe(2)
     })
 
     it('returns workspace "soft-deleted" if asked by the workspace owner', async () => {
@@ -383,13 +387,13 @@ describe('[core] workspace service', () => {
       // find workspaces with soft-deleted set to != null and workspace owner,
       // expect to find it
       expect.assertions(3)
-      // find workspaces, expect 2 (I think)
+      // find workspaces, expect 3 (I think)
       const workspaces = await app.service(SERVICES.CORE_WORKSPACE).find({
         query: {
           $limit: 0,
         },
       })
-      expect(workspaces.total).toBe(2)
+      expect(workspaces.total).toBe(3)
 
       // remove workspace as owner (so soft-deleted)
       await app.service(SERVICES.CORE_WORKSPACE).remove(resWorkspace.id, {
@@ -608,7 +612,7 @@ describe('[core] workspace service', () => {
         user: setupData.userCreator1,
         authentication: setupData.userCreator1Authentication,
       })
-      expect(allWs.total).toBe(3)
+      expect(allWs.total).toBe(4)
 
       const result = await app.service(SERVICES.CORE_WORKSPACE).find({
         query: {

--- a/api/src/services/workspace/datasource/datasource.test.ts
+++ b/api/src/services/workspace/datasource/datasource.test.ts
@@ -9,7 +9,7 @@ import { NotAcceptable } from '@feathersjs/errors'
 
 describe('[workspace] datasource service', () => {
   const app = createApp()
-  const builder = builderTestEnvironment('core-workspace')
+  const builder = builderTestEnvironment('workspace-datasource')
   let setupData: SetupData
   const port = app.get('port') || 8998
   let workspace: WorkspaceResult

--- a/api/src/services/workspace/datasource/datasource.test.ts
+++ b/api/src/services/workspace/datasource/datasource.test.ts
@@ -20,7 +20,7 @@ describe('[workspace] datasource service', () => {
 
     workspace = await app.service(SERVICES.CORE_WORKSPACE).create({
       name: 'Testing workspace datasource',
-      createdBy: setupData.user1.id,
+      createdBy: setupData.userCreator1.id,
     })
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
   api:
     dependencies:
       '@casl/ability':
-        specifier: ^5.4.4
-        version: 5.4.4
+        specifier: ^6.7.3
+        version: 6.7.3
       '@directus/schema':
         specifier: ^12.1.0
         version: 12.1.0(pg@8.12.0)(sqlite3@5.1.7)
@@ -132,6 +132,9 @@ importers:
       feathers-authentication-management:
         specifier: ^5.0.1
         version: 5.0.1(@feathersjs/feathers@5.0.10)(typescript@5.7.2)
+      feathers-casl:
+        specifier: ^2.2.0
+        version: 2.2.0(@casl/ability@6.7.3)(@feathersjs/feathers@5.0.10)
       feathers-hooks-common:
         specifier: ^7.0.3
         version: 7.0.3
@@ -834,8 +837,8 @@ packages:
   '@canvas/image-data@1.0.0':
     resolution: {integrity: sha512-BxOqI5LgsIQP1odU5KMwV9yoijleOPzHL18/YvNqF9KFSGF2K/DLlYAbDQsWqd/1nbaFuSkYD/191dpMtNh4vw==}
 
-  '@casl/ability@5.4.4':
-    resolution: {integrity: sha512-7+GOnMUq6q4fqtDDesymBXTS9LSDVezYhFiSJ8Rn3f0aQLeRm7qHn66KWbej4niCOvm0XzNj9jzpkK0yz6hUww==}
+  '@casl/ability@6.7.3':
+    resolution: {integrity: sha512-A4L28Ko+phJAsTDhRjzCOZWECQWN2jzZnJPnROWWHjJpyMq1h7h9ZqjwS2WbIUa3Z474X1ZPSgW0f1PboZGC0A==}
 
   '@chromatic-com/storybook@3.2.2':
     resolution: {integrity: sha512-xmXt/GW0hAPbzNTrxYuVo43Adrtjue4DeVrsoIIEeJdGaPNNeNf+DHMlJKOBdlHmCnFUoe9R/0mLM9zUp5bKWw==}
@@ -1364,6 +1367,10 @@ packages:
     resolution: {integrity: sha512-/eWhSiSw8U7hnB0KX9aW88EUitwW8phC8TykCJ/Vtv8jExZoZL8VWEjdZsRZoVk9fCu74sXrfRogwGhPMxiScA==}
     engines: {node: '>= 12'}
 
+  '@feathersjs/adapter-commons@5.0.31':
+    resolution: {integrity: sha512-x+RfY1H25ZGOmv/1p6Ob81AO/2KC+N2iJCVUFLItsHaGuMRn+s692GNYAl4Vk/kL3HzoPmfunSrCUxCXZ6MV5Q==}
+    engines: {node: '>= 12'}
+
   '@feathersjs/authentication-client@5.0.10':
     resolution: {integrity: sha512-2znAPVOYsHpUnnDhrOk+rtk1Kc4vuj27bB5NIKHCwsguwdT7M3fYRtZWx0JvmTLrMP5rsvFj6RpoTY52GVSNNg==}
     engines: {node: '>= 12'}
@@ -1472,6 +1479,10 @@ packages:
 
   '@feathersjs/transport-commons@5.0.25':
     resolution: {integrity: sha512-zLOlrtUg8tcFEvN+C7cYYPCS3C7zsP/Kw5HXIq89vg57S/8gCpBG0uh0++PaeyzIEFhX1+6qwnNM1JgtmtmEaw==}
+    engines: {node: '>= 12'}
+
+  '@feathersjs/transport-commons@5.0.31':
+    resolution: {integrity: sha512-md3dhUm47vh6aqPwb0T0Kj+LZI2JkRwMRTSx/X6w0n2evOB1x3/wspI4QY4JeUnPN0ab+IHlZVEF10FL0UQPQw==}
     engines: {node: '>= 12'}
 
   '@feathersjs/typebox@5.0.10':
@@ -4479,6 +4490,10 @@ packages:
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
+  fast-equals@5.2.2:
+    resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
+    engines: {node: '>=6.0.0'}
+
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
@@ -4504,6 +4519,13 @@ packages:
     peerDependencies:
       '@feathersjs/feathers': ^5.0.0
 
+  feathers-casl@2.2.0:
+    resolution: {integrity: sha512-17d1To8d3qy91KHZEmWXODYkzCZodzzo0Mwz5nBWh4uoEm4Xlz3t8msH0pbGpWQX/qWubjRtum+bErvPAgTz1w==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@casl/ability': 6.x
+      '@feathersjs/feathers': ^5.0.0
+
   feathers-hooks-common@7.0.3:
     resolution: {integrity: sha512-9qqYmvP5iYzfRLY2kOVmOVx4XmkFyQ8mZa81aofLa1RXfz2ULfpbCzE2PTcVz9ltekmMAKoHnWycVpI2ZaatCA==}
     engines: {node: '>= 14'}
@@ -4514,9 +4536,21 @@ packages:
     peerDependencies:
       '@feathersjs/feathers': ^5.0.0
 
+  feathers-hooks-common@8.2.1:
+    resolution: {integrity: sha512-t3gLAaTY5ufnAoKczLCNXJddq/L9ORrvxAlfuU2Azgoi0b6X3t0Y91l1JCJAvixzxxwLJmgdnKpFX32+CvEn0A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@feathersjs/feathers': ^5.0.0
+
   feathers-swagger@3.0.0:
     resolution: {integrity: sha512-RBM3FZpV9teyPZA1TrsZ49an2q07LEFZUVMJeib2hEo2+H2nj3YM3wlm/kXePUZQPD5ugaWXwgnJJlADW/+w1A==}
     engines: {node: '>= 14'}
+
+  feathers-utils@7.0.0:
+    resolution: {integrity: sha512-TtQCqH2S0Y0wgCwTJIF96/8ivS+AG3WIqdXGvg14BDCDxiOlM3MyI3HC8f1Ku78QyBt2e1D5XnAH01kqMTc0UA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@feathersjs/feathers': ^5.0.0
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
@@ -4752,6 +4786,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  graphql@16.10.0:
+    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   graphql@16.8.1:
     resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
@@ -5715,6 +5753,10 @@ packages:
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+
+  neotraverse@0.6.18:
+    resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
+    engines: {node: '>= 10'}
 
   node-abi@3.63.0:
     resolution: {integrity: sha512-vAszCsOUrUxjGAmdnM/pq7gUgie0IRteCQMX6d4A534fQCR93EJU5qgzBvU6EkFfK27s0T3HEV3BOyJIr7OMYw==}
@@ -8091,7 +8133,7 @@ snapshots:
 
   '@canvas/image-data@1.0.0': {}
 
-  '@casl/ability@5.4.4':
+  '@casl/ability@6.7.3':
     dependencies:
       '@ucast/mongo2js': 1.3.4
 
@@ -8431,7 +8473,13 @@ snapshots:
   '@feathersjs/adapter-commons@5.0.25':
     dependencies:
       '@feathersjs/commons': 5.0.31
-      '@feathersjs/errors': 5.0.25
+      '@feathersjs/errors': 5.0.31
+      '@feathersjs/feathers': 5.0.31
+
+  '@feathersjs/adapter-commons@5.0.31':
+    dependencies:
+      '@feathersjs/commons': 5.0.31
+      '@feathersjs/errors': 5.0.31
       '@feathersjs/feathers': 5.0.31
 
   '@feathersjs/authentication-client@5.0.10(typescript@5.4.5)':
@@ -8456,7 +8504,7 @@ snapshots:
     dependencies:
       '@feathersjs/authentication': 5.0.25(typescript@5.7.2)
       '@feathersjs/commons': 5.0.31
-      '@feathersjs/errors': 5.0.25
+      '@feathersjs/errors': 5.0.31
       '@feathersjs/feathers': 5.0.31
     transitivePeerDependencies:
       - typescript
@@ -8476,7 +8524,7 @@ snapshots:
     dependencies:
       '@feathersjs/authentication': 5.0.25(typescript@5.7.2)
       '@feathersjs/commons': 5.0.31
-      '@feathersjs/errors': 5.0.25
+      '@feathersjs/errors': 5.0.31
       '@feathersjs/feathers': 5.0.31
       bcryptjs: 2.4.3
       lodash: 4.17.21
@@ -8536,7 +8584,7 @@ snapshots:
   '@feathersjs/authentication@5.0.25(typescript@5.7.2)':
     dependencies:
       '@feathersjs/commons': 5.0.31
-      '@feathersjs/errors': 5.0.25
+      '@feathersjs/errors': 5.0.31
       '@feathersjs/feathers': 5.0.31
       '@feathersjs/hooks': 0.9.0
       '@feathersjs/schema': 5.0.25(typescript@5.7.2)
@@ -8573,7 +8621,7 @@ snapshots:
     dependencies:
       '@feathersjs/authentication': 5.0.25(typescript@5.7.2)
       '@feathersjs/commons': 5.0.31
-      '@feathersjs/errors': 5.0.25
+      '@feathersjs/errors': 5.0.31
       '@feathersjs/feathers': 5.0.31
       '@feathersjs/transport-commons': 5.0.25
       '@types/compression': 1.7.5
@@ -8670,7 +8718,7 @@ snapshots:
     dependencies:
       '@feathersjs/adapter-commons': 5.0.25
       '@feathersjs/commons': 5.0.31
-      '@feathersjs/errors': 5.0.25
+      '@feathersjs/errors': 5.0.31
       '@feathersjs/feathers': 5.0.31
       '@feathersjs/hooks': 0.9.0
       '@types/json-schema': 7.0.15
@@ -8701,7 +8749,15 @@ snapshots:
   '@feathersjs/transport-commons@5.0.25':
     dependencies:
       '@feathersjs/commons': 5.0.31
-      '@feathersjs/errors': 5.0.25
+      '@feathersjs/errors': 5.0.31
+      '@feathersjs/feathers': 5.0.31
+      encodeurl: 2.0.0
+      lodash: 4.17.21
+
+  '@feathersjs/transport-commons@5.0.31':
+    dependencies:
+      '@feathersjs/commons': 5.0.31
+      '@feathersjs/errors': 5.0.31
       '@feathersjs/feathers': 5.0.31
       encodeurl: 2.0.0
       lodash: 4.17.21
@@ -10557,7 +10613,7 @@ snapshots:
       std-env: 3.8.0
       strip-literal: 2.1.0
       test-exclude: 6.0.0
-      vitest: 1.6.0(@types/node@22.9.3)(@vitest/ui@1.6.0)(jsdom@25.0.1)(sass@1.77.4)(terser@5.31.1)
+      vitest: 1.6.0(@types/node@20.14.2)(@vitest/ui@1.6.0)(jsdom@25.0.1)(sass@1.77.4)(terser@5.31.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12639,6 +12695,8 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
+  fast-equals@5.2.2: {}
+
   fast-fifo@1.3.2: {}
 
   fast-glob@3.3.2:
@@ -12675,6 +12733,18 @@ snapshots:
       - supports-color
       - typescript
 
+  feathers-casl@2.2.0(@casl/ability@6.7.3)(@feathersjs/feathers@5.0.10):
+    dependencies:
+      '@casl/ability': 6.7.3
+      '@feathersjs/errors': 5.0.31
+      '@feathersjs/feathers': 5.0.10
+      '@feathersjs/transport-commons': 5.0.31
+      feathers-hooks-common: 8.2.1(@feathersjs/feathers@5.0.10)
+      feathers-utils: 7.0.0(@feathersjs/feathers@5.0.10)
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
+
   feathers-hooks-common@7.0.3:
     dependencies:
       '@feathers-plus/batch-loader': 0.3.6
@@ -12691,7 +12761,7 @@ snapshots:
 
   feathers-hooks-common@8.1.2(@feathersjs/feathers@5.0.10):
     dependencies:
-      '@feathersjs/errors': 5.0.25
+      '@feathersjs/errors': 5.0.31
       '@feathersjs/feathers': 5.0.10
       ajv: 6.12.6
       debug: 4.3.7
@@ -12701,9 +12771,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  feathers-hooks-common@8.2.1(@feathersjs/feathers@5.0.10):
+    dependencies:
+      '@feathersjs/errors': 5.0.31
+      '@feathersjs/feathers': 5.0.10
+      ajv: 6.12.6
+      debug: 4.3.7
+      graphql: 16.10.0
+      lodash: 4.17.21
+      neotraverse: 0.6.18
+    transitivePeerDependencies:
+      - supports-color
+
   feathers-swagger@3.0.0:
     dependencies:
       lodash: 4.17.21
+
+  feathers-utils@7.0.0(@feathersjs/feathers@5.0.10):
+    dependencies:
+      '@feathersjs/adapter-commons': 5.0.31
+      '@feathersjs/errors': 5.0.31
+      '@feathersjs/feathers': 5.0.10
+      fast-equals: 5.2.2
+      feathers-hooks-common: 8.2.1(@feathersjs/feathers@5.0.10)
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
 
   fecha@4.2.3: {}
 
@@ -12953,6 +13046,8 @@ snapshots:
       jws: 4.0.0
 
   graphemer@1.4.0: {}
+
+  graphql@16.10.0: {}
 
   graphql@16.8.1: {}
 
@@ -13985,6 +14080,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
+
+  neotraverse@0.6.18: {}
 
   node-abi@3.63.0:
     dependencies:


### PR DESCRIPTION
WIP

**for `core/datasource` service**
* forbid non admin users to access this endpoint, internal & external calls
* allow internal calls for admin users
* allow internal calls for no users calls (truely internal calls)
* allow external calls for admin users

**for `core/group` service**
* for `MEMBER`
  * can read groups they are member of
  * cannot update/delete group
* for `CREATOR`
  * can read groups they are member of
  * can only update / delete groups of their workspaces 
* for `ADMIN`
  * can manage all groups